### PR TITLE
Make AI scripts working

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -24,6 +24,9 @@ set(install_files
 	${CMAKE_CURRENT_BINARY_DIR}/scripts.zip
 	${CMAKE_CURRENT_BINARY_DIR}/backgrounds.zip
 	${CMAKE_CURRENT_BINARY_DIR}/rules.zip
+	api.lua
+	bot_api.lua
+	rules_api.lua
 	Icon.bmp
 	config.xml
 	inputconfig.xml


### PR DESCRIPTION
Hi,

I'm rebasing the OpenBSD ports of Blobby Volley on this codebase. While testing, i've found out  that AI scripts where not working, so i added them back.

I wonder if there is a reason why they are omitted? 