### PR TITLE
Fix building on newer Linux systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,10 @@ find_package(PhysFS REQUIRED)
 find_package(OpenGL)
 find_package(SDL2 REQUIRED)
 
+if ("${SDL2_LIBRARIES}" STREQUAL "")
+	set(SDL2_LIBRARIES "SDL2::SDL2")
+endif ("${SDL2_LIBRARIES}" STREQUAL "")
+
 if (NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
 	find_package(Threads REQUIRED)
 endif (NOT CMAKE_SYSTEM_NAME STREQUAL Windows)


### PR DESCRIPTION
The way SDL2 is included doesn't seem to be compatible with the way newer versions of SDL2 do their CMake integration (`${SDL2_LIBRARIES}` was empty). I've fixed it, in a hopefully backwards-compatible way, to be able to build on Arch Linux.