### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -86,7 +86,11 @@ bool FileSystem::exists(const std::string& filename) const
 
 bool FileSystem::isDirectory(const std::string& dirname) const
 {
-	return PHYSFS_isDirectory(dirname.c_str());
+	PHYSFS_Stat stat;
+	if ( !PHYSFS_stat(dirname.c_str(), &stat) )
+		BOOST_THROW_EXCEPTION( PhysfsException() );
+
+	return stat.filetype == PHYSFS_FILETYPE_DIRECTORY;
 }
 
 bool FileSystem::mkdir(const std::string& dirname)
@@ -97,15 +101,13 @@ bool FileSystem::mkdir(const std::string& dirname)
 void FileSystem::addToSearchPath(const std::string& dirname, bool append)
 {
 	/// \todo check if dir exists?
-	/// \todo use PHYSFS_mount? PHYSFS_addToSearchPath is listed as legacy function only there for binary 
-	///  compatibility with older version.
 	/// \todo check return value
-	PHYSFS_addToSearchPath(dirname.c_str(), append ? 1 : 0);
+	PHYSFS_mount(dirname.c_str(), nullptr, append ? 1 : 0);
 }
 
 void FileSystem::removeFromSearchPath(const std::string& dirname)
 {
-	PHYSFS_removeFromSearchPath(dirname.c_str());
+	PHYSFS_unmount(dirname.c_str());
 }
 
 void FileSystem::setWriteDir(const std::string& dirname)

--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -854,7 +854,7 @@ SelectBoxAction IMGUI::doSelectbox(int id, const Vector2& pos1, const Vector2& p
 				int tmp = (int)((mousepos.y - pos1.y - 5) / FontSize) + first;
 				/// \todo well, it's not really a doulbe click...
 				/// we need to do this in inputmanager
-				if( selected == tmp && InputManager::getSingleton()->doubleClick() )
+				if( selected == static_cast<unsigned int>(tmp) && InputManager::getSingleton()->doubleClick() )
 					changed = SBA_DBL_CLICK;
 
 				if (tmp >= 0 && static_cast<unsigned int>(tmp) < entries.size())

--- a/src/NetworkMessage.cpp
+++ b/src/NetworkMessage.cpp
@@ -77,7 +77,7 @@ void ServerInfo::writeToBitstream(RakNet::BitStream& stream)
 	stream.Write(name, sizeof(name));
 	stream.Write(waitingplayers);
 	stream.Write(description, sizeof(description));
-	assert( stream.GetNumberOfBytesUsed() == BLOBBY_SERVER_PRESENT_PACKET_SIZE);
+	assert( stream.GetNumberOfBytesUsed() == static_cast<int>(BLOBBY_SERVER_PRESENT_PACKET_SIZE) );
 }
 
 const size_t ServerInfo::BLOBBY_SERVER_PRESENT_PACKET_SIZE = sizeof((unsigned char)ID_BLOBBY_SERVER_PRESENT)

--- a/src/NetworkMessage.cpp
+++ b/src/NetworkMessage.cpp
@@ -51,7 +51,12 @@ ServerInfo::ServerInfo(const IUserConfigReader& config)
 	std::string n = "Blobby Volley 2 Server";
 	std::string d = "no description available";
 
-	memset(this, 0, sizeof(ServerInfo));
+	activegames = 0;
+	memset(hostname, 0, sizeof(hostname));
+	memset(name, 0, sizeof(name));
+	memset(description, 0, sizeof(description));
+	waitingplayers = 0;
+
 	std::string tmp;
 	tmp = config.getString("name", n);
 	strncpy(name, tmp.c_str(), sizeof(name) - 1);
@@ -62,7 +67,11 @@ ServerInfo::ServerInfo(const IUserConfigReader& config)
 
 ServerInfo::ServerInfo(const std::string& playername)
 {
-	memset(this, 0, sizeof(ServerInfo));
+	activegames = 0;
+	memset(hostname, 0, sizeof(hostname));
+	memset(name, 0, sizeof(name));
+	memset(description, 0, sizeof(description));
+	waitingplayers = 0;
 
 	std::strncpy(hostname, "localhost", sizeof(hostname));
 	port = BLOBBY_PORT;

--- a/src/RenderManagerGL2D.cpp
+++ b/src/RenderManagerGL2D.cpp
@@ -480,7 +480,7 @@ bool RenderManagerGL2D::setBackground(const std::string& filename)
 		mBackground = imgBuffer->glHandle;
 		mImageMap["background"] = imgBuffer;
 	}
-	catch (FileLoadException)
+	catch (const FileLoadException&)
 	{
 		return false;
 	}

--- a/src/RenderManagerGP2X.cpp
+++ b/src/RenderManagerGP2X.cpp
@@ -269,7 +269,7 @@ bool RenderManagerGP2X::setBackground(const std::string& filename)
 		mBackground = SDL_DisplayFormat(tempBackground);
 		SDL_FreeSurface(tempBackground);
 	}
-	catch (FileLoadException)
+	catch (const FileLoadException&)
 	{
 		return false;
 	}

--- a/src/RenderManagerSDL.cpp
+++ b/src/RenderManagerSDL.cpp
@@ -493,7 +493,7 @@ bool RenderManagerSDL::setBackground(const std::string& filename)
 		mBackground = newImage->sdlImage;
 		mImageMap["background"] = newImage;
 	}
-	catch (FileLoadException)
+	catch (const FileLoadException&)
 	{
 		return false;
 	}

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -141,7 +141,7 @@ std::string encode( const char* begin, const char* end, int newlines)
 	for(unsigned i = 0; i < groups; ++i)
 	{
 		encode(read, write);
-		if( newlines > 0 && (i+1) * 4 >= last_newline + newlines )
+		if( newlines > 0 && (i+1) * 4 >= static_cast<unsigned>(last_newline + newlines) )
 		{
 			*write = '\n';
 			write++;

--- a/src/replays/ReplayLoader.cpp
+++ b/src/replays/ReplayLoader.cpp
@@ -309,7 +309,7 @@ class ReplayLoader_V2X: public IReplayLoader
 		unsigned int mRightFinalScore;
 		unsigned int mGameSpeed;
 		unsigned int mGameDate;
-		unsigned int mGameLength;
+		int mGameLength;
 		unsigned int mGameDuration;
 		Color mLeftColor;
 		Color mRightColor;


### PR DESCRIPTION
This fixes most of the compiler warnings (gcc 9.3 under Linux) when building Blobby Volley 2. The only warning I didn't fix was about `PHYSFS_getUserDir()` being deprecated, because fixing that would introduce changes to where save data is stored.