### PR TITLE
Run build CI with a multitude of compilers.

### DIFF
--- a/.github/workflows/compilers.yaml
+++ b/.github/workflows/compilers.yaml
@@ -15,6 +15,7 @@ jobs:
           - { name: "Clang 12", cxx: "clang++-12", cc: "clang-12", install: "clang-12",        os: "ubuntu-22.04"}
           - { name: "Clang 13", cxx: "clang++-13", cc: "clang-13", install: "clang-13",        os: "ubuntu-22.04"}
           - { name: "Clang 14", cxx: "clang++-14", cc: "clang-14", install: "clang-14",        os: "ubuntu-22.04"}
+          - { name: "GCC 5",    cxx: "g++-5",      cc: "gcc-5",    install: "g++-5 gcc-5",     os: "ubuntu-18.04"}
           - { name: "GCC 6",    cxx: "g++-6",      cc: "gcc-6",    install: "g++-6 gcc-6",     os: "ubuntu-18.04"}
           - { name: "GCC 7",    cxx: "g++-7",      cc: "gcc-7",    install: "g++-7 gcc-7",     os: "ubuntu-20.04"}
           - { name: "GCC 9",    cxx: "g++-9",      cc: "gcc-9",    install: "g++-9 gcc-9",     os: "ubuntu-22.04"}

--- a/.github/workflows/compilers.yaml
+++ b/.github/workflows/compilers.yaml
@@ -1,0 +1,45 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  Build:
+    name: ${{ matrix.compiler.name }}
+    runs-on: ${{ matrix.compiler.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { name: "Clang 10", cxx: "clang++-10", cc: "clang-10", install: "clang-10",        os: "ubuntu-20.04"}
+          - { name: "Clang 12", cxx: "clang++-12", cc: "clang-12", install: "clang-12",        os: "ubuntu-22.04"}
+          - { name: "Clang 13", cxx: "clang++-13", cc: "clang-13", install: "clang-13",        os: "ubuntu-22.04"}
+          - { name: "Clang 14", cxx: "clang++-14", cc: "clang-14", install: "clang-14",        os: "ubuntu-22.04"}
+          - { name: "GCC 6",    cxx: "g++-6",      cc: "gcc-6",    install: "g++-6 gcc-6",     os: "ubuntu-18.04"}
+          - { name: "GCC 7",    cxx: "g++-7",      cc: "gcc-7",    install: "g++-7 gcc-7",     os: "ubuntu-20.04"}
+          - { name: "GCC 9",    cxx: "g++-9",      cc: "gcc-9",    install: "g++-9 gcc-9",     os: "ubuntu-22.04"}
+          - { name: "GCC 10",   cxx: "g++-10",     cc: "gcc-10",   install: "g++-10 gcc-10",   os: "ubuntu-22.04"}
+          - { name: "GCC 11",   cxx: "g++-11",     cc: "gcc-11",   install: "g++-11 gcc-11",   os: "ubuntu-22.04"}
+          - { name: "GCC 12",   cxx: "g++-12",     cc: "gcc-12",   install: "g++-12 gcc-12",   os: "ubuntu-22.04"}
+
+    steps:
+      - name: Install Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            cmake \
+            libsdl2-dev \
+            libphysfs-dev \
+            libboost-dev \
+            ${{matrix.compiler.install}}
+      - name: Setup Environment
+        run: |
+          CXX="${{matrix.compiler.cxx}}" 
+          echo "CXX=${CXX}" >> $GITHUB_ENV
+          CC="${{matrix.compiler.cc}}" 
+          echo "CC=${CC}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: Configure CMake and Build
+        run: |
+          cmake .
+          cmake --build .

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ git clone https://github.com/danielknobe/blobbyvolley2.git
 ```
 
 ### Build under Linux
+Blobby Volley compiles with GCC 6 or newer, or Clang 10 or newer.
+Other compilers may work but are currently untested.
 
 1. Install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://github.com/danielknobe/blobbyvolley2.git
 ```
 
 ### Build under Linux
-Blobby Volley compiles with GCC 6 or newer, or Clang 10 or newer.
+Blobby Volley compiles with GCC 5 or newer, or Clang 10 or newer.
 Other compilers may work but are currently untested.
 
 1. Install dependencies:

--- a/doc/codeconvention/codeconvention.tex
+++ b/doc/codeconvention/codeconvention.tex
@@ -136,7 +136,7 @@ This section describes the coding style. If you think something is missing just 
 	\item Do not write more than one statement into one source line
 	\item Break statements within switch are followed by an empty line
 	\item Use smart pointers when ever possible
-	\item Code should be gcc 4.6 compatible
+	\item Code should be gcc 6 compatible
 	\item Code should compile in c++11 mode
 	\item Don't use the deprecated exception handling of older c++ versions
 	\item Binary/ternary operators are seperated from their operands by spaces (exception: long expression - for grouping purposes)

--- a/doc/codeconvention/codeconvention.tex
+++ b/doc/codeconvention/codeconvention.tex
@@ -136,7 +136,7 @@ This section describes the coding style. If you think something is missing just 
 	\item Do not write more than one statement into one source line
 	\item Break statements within switch are followed by an empty line
 	\item Use smart pointers when ever possible
-	\item Code should be gcc 6 compatible
+	\item Code should be gcc 5 compatible
 	\item Code should compile in c++11 mode
 	\item Don't use the deprecated exception handling of older c++ versions
 	\item Binary/ternary operators are seperated from their operands by spaces (exception: long expression - for grouping purposes)

--- a/src/blobnet/CMakeLists.txt
+++ b/src/blobnet/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 11)
+
 set (blobnet_SRC
 	layer/Http.cpp layer/Http.hpp
 	)

--- a/src/raknet/CMakeLists.txt
+++ b/src/raknet/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 11)
+
 set (raknet_SRC
 	ArrayList.h
 	BitStream.cpp BitStream.h


### PR DESCRIPTION
Add CI runs for different versions of compilers. 
Officially state that GCC 6 is currently the oldest working compiler.

For testing that, we need the `ubuntu-18.04` image, which is still available but deprecated, and slated for removal next spring.