### PR TITLE
Clang tidy

### DIFF
--- a/src/BlobbyDebug.cpp
+++ b/src/BlobbyDebug.cpp
@@ -65,7 +65,7 @@ int getObjectCount(const std::type_info& type)
 
 int count(const std::type_info& type, std::string tag, int n)
 {
-	std::string name = std::string(type.name()) + " - " + tag;
+	std::string name = std::string(type.name()) + " - " + std::move(tag);
 	if(GetCounterMap().find(name) == GetCounterMap().end() )
 	{
 		GetCounterMap()[name] = CountingReport();
@@ -76,13 +76,13 @@ int count(const std::type_info& type, std::string tag, int n)
 
 int uncount(const std::type_info& type, std::string tag, int n)
 {
-	return GetCounterMap()[std::string(type.name()) + " - " + tag].alive -= n;
+	return GetCounterMap()[std::string(type.name()) + " - " + std::move(tag)].alive -= n;
 }
 
 int count(const std::type_info& type, std::string tag, void* address, int num)
 {
 	std::cout << "MALLOC " << num << "\n";
-	count(type, tag, num);
+	count(type, std::move(tag), num);
 	GetAddressMap()[address] = num;
 	return 0;
 }
@@ -91,13 +91,13 @@ int uncount(const std::type_info& type, std::string tag, void* address)
 {
 	int num = GetAddressMap()[address];
 	std::cout << "FREE " << num << "\n";
-	uncount(type, tag, num);
+	uncount(type, std::move(tag), num);
 	return 0;
 }
 
 void debug_count_execution_fkt(std::string file, int line)
 {
-	std::string rec = file + ":" + std::to_string(line);
+	std::string rec = std::move(file) + ":" + std::to_string(line);
 	if(GetProfMap().find(rec) == GetProfMap().end() )
 	{
 		GetProfMap()[rec] = 0;

--- a/src/BlobbyDebug.h
+++ b/src/BlobbyDebug.h
@@ -97,10 +97,10 @@ struct CountingAllocator : private std::allocator<T>
 	{
 	}
 
-	template<typename _Tp1>
+	template<typename Tp1_>
 	struct rebind
 	{
-		typedef CountingAllocator<_Tp1, tag_type> other;
+		typedef CountingAllocator<Tp1_, tag_type> other;
 	};
 
 

--- a/src/BlobbyDebug.h
+++ b/src/BlobbyDebug.h
@@ -105,7 +105,7 @@ struct CountingAllocator : private std::allocator<T>
 
 
 
-	pointer allocate (size_type n, std::allocator<void>::const_pointer hint = 0)
+	pointer allocate (size_type n, std::allocator<void>::const_pointer hint = nullptr)
 	{
 		count(typeid(T), tag_type::tag(), n);
 		return Base::allocate(n, hint);

--- a/src/Blood.cpp
+++ b/src/Blood.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* implementation */
 
 
-BloodManager* BloodManager::mSingleton = NULL;
+BloodManager* BloodManager::mSingleton = nullptr;
 
 // Blood class
 // ------------

--- a/src/Blood.cpp
+++ b/src/Blood.cpp
@@ -78,10 +78,10 @@ void BloodManager::step()
 	RenderManager::getSingleton().startDrawParticles();
 	
 	// iterate over all particles
-	std::list<Blood>::iterator it = mParticles.begin();
+	auto it = mParticles.begin();
 	while (it != mParticles.end())
 	{
-		std::list<Blood>::iterator it2 = it;
+		auto it2 = it;
 		++it;	
 		it2->step();
 		// delete particles below lower screen border

--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -50,17 +50,17 @@ DuelMatch::DuelMatch(bool remote, std::string rules, int score_to_win) :
 
 void DuelMatch::setPlayers( PlayerIdentity lplayer, PlayerIdentity rplayer)
 {
-	mPlayers[LEFT_PLAYER] = lplayer;
-	mPlayers[RIGHT_PLAYER] = rplayer;
+	mPlayers[LEFT_PLAYER] = std::move(lplayer);
+	mPlayers[RIGHT_PLAYER] = std::move(rplayer);
 }
 
 void DuelMatch::setInputSources(std::shared_ptr<InputSource> linput, std::shared_ptr<InputSource> rinput )
 {
 	if(linput)
-		mInputSources[LEFT_PLAYER] = linput;
+		mInputSources[LEFT_PLAYER] = std::move(linput);
 
 	if(rinput)
-		mInputSources[RIGHT_PLAYER] = rinput;
+		mInputSources[RIGHT_PLAYER] = std::move(rinput);
 
 	mInputSources[LEFT_PLAYER]->setMatch(this);
 	mInputSources[RIGHT_PLAYER]->setMatch(this);

--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -72,9 +72,7 @@ void DuelMatch::reset()
 	mLogic = mLogic->clone();
 }
 
-DuelMatch::~DuelMatch()
-{
-}
+DuelMatch::~DuelMatch() = default;
 
 void DuelMatch::setRules(std::string rulesFile, int score_to_win)
 {

--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -225,7 +225,7 @@ Vector2 DuelMatch::getBlobPosition(PlayerSide player) const
 	if (player == LEFT_PLAYER || player == RIGHT_PLAYER)
 		return mPhysicWorld->getBlobPosition(player);
 	else
-		return Vector2(0.f, 0.f);
+		return {0.f, 0.f};
 }
 
 Vector2 DuelMatch::getBlobVelocity(PlayerSide player) const
@@ -233,7 +233,7 @@ Vector2 DuelMatch::getBlobVelocity(PlayerSide player) const
 	if (player == LEFT_PLAYER || player == RIGHT_PLAYER)
 		return mPhysicWorld->getBlobVelocity(player);
 	else
-		return Vector2(0.f, 0.f);
+		return {0.f, 0.f};
 }
 
 Vector2 DuelMatch::getBallPosition() const

--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -225,7 +225,7 @@ Vector2 DuelMatch::getBlobPosition(PlayerSide player) const
 	if (player == LEFT_PLAYER || player == RIGHT_PLAYER)
 		return mPhysicWorld->getBlobPosition(player);
 	else
-		return Vector2(0.0, 0.0);
+		return Vector2(0.f, 0.f);
 }
 
 Vector2 DuelMatch::getBlobVelocity(PlayerSide player) const
@@ -233,7 +233,7 @@ Vector2 DuelMatch::getBlobVelocity(PlayerSide player) const
 	if (player == LEFT_PLAYER || player == RIGHT_PLAYER)
 		return mPhysicWorld->getBlobVelocity(player);
 	else
-		return Vector2(0.0, 0.0);
+		return Vector2(0.f, 0.f);
 }
 
 Vector2 DuelMatch::getBallPosition() const

--- a/src/DuelMatch.h
+++ b/src/DuelMatch.h
@@ -91,7 +91,7 @@ class DuelMatch : public ObjectCounter<DuelMatch>
 		Vector2 getBlobPosition(PlayerSide player) const;
 		Vector2 getBlobVelocity(PlayerSide player) const;
 
-		const PhysicWorld& getWorld() const{ return *mPhysicWorld.get(); };
+		const PhysicWorld& getWorld() const{ return *mPhysicWorld; };
 		const Clock& getClock() const;
 		Clock& getClock();
 

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -91,8 +91,8 @@ void File::close()
 			/// we can't throw an error here, as this function gets called
 			/// in the destructor and therefore might be called while another
 			/// excpetion is active so we cant throw.
-		};
-		mHandle = 0;
+		}
+		mHandle = nullptr;
 		mFileName = "";
 	}
 }

--- a/src/File.h
+++ b/src/File.h
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #pragma once
 
 #include <string>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <boost/noncopyable.hpp>
 #include <boost/shared_array.hpp>

--- a/src/FileExceptions.h
+++ b/src/FileExceptions.h
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <string>
 
 #include <boost/exception/all.hpp>
+#include <utility>
 
 /*! \class FileSystemException
 	\brief common base class of all file system related errors
@@ -73,7 +74,7 @@ class PhysfsException : public virtual FileSystemException
 class PhysfsInitException : public PhysfsException
 {
 	public:
-		explicit PhysfsInitException(const std::string& path) : mPath(path)
+		explicit PhysfsInitException(std::string path) : mPath(std::move(path))
 		{
 
 		}
@@ -101,7 +102,7 @@ class PhysfsInitException : public PhysfsException
 */
 class FileException: public virtual FileSystemException {
 	public:
-		explicit FileException(const std::string& f) : filename(f)
+		explicit FileException(std::string f) : filename(std::move(f))
 		{
 		}
 

--- a/src/FileRead.cpp
+++ b/src/FileRead.cpp
@@ -128,7 +128,7 @@ float FileRead::readFloat()
 std::string FileRead::readString()
 {
 	char buffer[32]; 		// thats our read buffer
-	std::string read = "";	// thats what we read so far
+	std::string read;	    // thats what we read so far
 	size_t len = length();
 
 	while(true)	// check that we can read as much as want

--- a/src/FileRead.cpp
+++ b/src/FileRead.cpp
@@ -44,18 +44,13 @@ extern "C"
 
 /* implementation */
 
-FileRead::FileRead()
-{
-}
+FileRead::FileRead() = default;
 
 FileRead::FileRead(const std::string& filename) : File(filename, File::OPEN_READ)
 {
 }
 
-FileRead::~FileRead()
-{
-	// no more actions than what ~File already does
-}
+FileRead::~FileRead() = default;
 
 void FileRead::open(const std::string& filename)
 {
@@ -148,7 +143,7 @@ std::string FileRead::readString()
 				seek( tell() - maxread + i + 1);
 				return read;
 			}
-			 else
+			else
 			{
 				read += buffer[i];	// this might not be the most efficient way...
 			}
@@ -222,9 +217,9 @@ static const char* chunkReader(lua_State* state, void* data, size_t *size)
 	*size = bytesRead;
 	if (bytesRead == 0)
 	{
-		return 0;
+		return nullptr;
 	}
-	 else
+	else
 	{
 		return info->buffer;
 	}
@@ -234,7 +229,7 @@ int FileRead::readLuaScript(const std::string& filename, lua_State* mState)
 {
 	ReaderInfo info;
 	info.file.open(makeLuaFilename(filename));
-	return lua_load(mState, chunkReader, &info, filename.c_str(), NULL);
+	return lua_load(mState, chunkReader, &info, filename.c_str(), nullptr);
 }
 
 std::string FileRead::makeLuaFilename(std::string filename)

--- a/src/FileRead.h
+++ b/src/FileRead.h
@@ -53,7 +53,7 @@ class FileRead : public File
 		/// \brief constructor which opens a file.
 		/// \param filename File to be opened for reading
 		/// \throw FileLoadException, if the file could not be loaded
-		FileRead(const std::string& filename);
+		explicit FileRead(const std::string& filename);
 		
 		/// \brief opens a file.
 		/// \param filename File to be opened for reading

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -117,7 +117,7 @@ void FileSystem::setWriteDir(const std::string& dirname)
 	if( !PHYSFS_setWriteDir(dirname.c_str()) )
 	{
 		BOOST_THROW_EXCEPTION( PhysfsException() );
-	};
+	}
 	addToSearchPath(dirname, false);
 }
 

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -64,7 +64,7 @@ std::vector<std::string> FileSystem::enumerateFiles(const std::string& directory
 		int position = tmp.length() - extension.length();
 		if (position >= 0 && tmp.substr(position) == extension)
 		{
-			files.push_back(std::string(tmp.begin(), keepExtension ? (tmp.end()) : (tmp.end() - extension.length()) ));
+			files.emplace_back(tmp.begin(), keepExtension ? (tmp.end()) : (tmp.end() - extension.length()) );
 		}
 	}
 	

--- a/src/FileWrite.cpp
+++ b/src/FileWrite.cpp
@@ -31,18 +31,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* implementation */
 
-FileWrite::FileWrite()
-{
-}
+FileWrite::FileWrite() = default;
 
 FileWrite::FileWrite(const std::string& filename, bool no_override) : File(filename, File::OPEN_WRITE, no_override)
 {
 }
 
-FileWrite::~FileWrite()
-{
-	// no more actions than what ~File already does
-}
+FileWrite::~FileWrite() = default;
 
 void FileWrite::open(const std::string& filename, bool no_override)
 {

--- a/src/FileWrite.h
+++ b/src/FileWrite.h
@@ -44,7 +44,7 @@ class FileWrite : public File
 		/// \param no_override Set to true if you want to forbid writing over existing file.
 		/// \throw FileLoadException, if the file could not be loaded
 		/// \throw FileAlreadyExistsException in case of trying to write over existing file with no_override = true
-		FileWrite(const std::string& filename, bool no_override = false);
+		explicit FileWrite(const std::string& filename, bool no_override = false);
 		
 		/// \brief opens a file.
 		/// \param filename File to be opened for writing

--- a/src/GameConstants.h
+++ b/src/GameConstants.h
@@ -37,12 +37,12 @@ const float BLOBBY_LOWER_RADIUS = 33;
 
 // Ground Settings
 const float GROUND_PLANE_HEIGHT_MAX = 500;
-const float GROUND_PLANE_HEIGHT = GROUND_PLANE_HEIGHT_MAX - BLOBBY_HEIGHT / 2.0;
+const float GROUND_PLANE_HEIGHT = GROUND_PLANE_HEIGHT_MAX - BLOBBY_HEIGHT / 2.f;
 
 
 // This is exactly the half of the gravitation, i checked it in
 // the original code
-const float BLOBBY_MAX_JUMP_HEIGHT = GROUND_PLANE_HEIGHT - 206.375;	// GROUND_Y - MAX_Y
+const float BLOBBY_MAX_JUMP_HEIGHT = GROUND_PLANE_HEIGHT - 206.375f;	// GROUND_Y - MAX_Y
 const float BLOBBY_JUMP_ACCELERATION = -15.1;
 
 // these values are calculated from the other two
@@ -53,7 +53,7 @@ const float BLOBBY_JUMP_BUFFER = GRAVITATION / 2;
 // Ball Settings
 const float BALL_RADIUS = 31.5;
 const float BALL_GRAVITATION = 0.287;
-const float BALL_COLLISION_VELOCITY = std::sqrt(0.75 * RIGHT_PLANE * BALL_GRAVITATION); /// \todo work on a full-fledged physics spec
+const float BALL_COLLISION_VELOCITY = std::sqrt(0.75f * RIGHT_PLANE * BALL_GRAVITATION); /// \todo work on a full-fledged physics spec
 
 
 // Volley Ball Net

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -494,7 +494,7 @@ LuaGameLogic::LuaGameLogic( std::string filename, DuelMatch* match, int score_to
 	mTitle = ( title ? title : "untitled script" );
 	lua_pop(mState, 1);
 
-	std::cout << "loaded rules "<< getTitle()<< " by " << getAuthor() << " from " << mSourceFile << std::endl;
+	std::cout << "loaded rules "<< mTitle<< " by " << mAuthor << " from " << mSourceFile << std::endl;
 }
 
 LuaGameLogic::~LuaGameLogic() = default;

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -324,7 +324,7 @@ void IGameLogic::onError(PlayerSide errorSide, PlayerSide serveSide)
 class FallbackGameLogic : public IGameLogic
 {
 	public:
-		FallbackGameLogic( int stw ) : IGameLogic( stw )
+		explicit FallbackGameLogic( int stw ) : IGameLogic( stw )
 		{
 		}
 		~FallbackGameLogic() override = default;

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -337,7 +337,7 @@ class FallbackGameLogic : public IGameLogic
 
 		std::string getSourceFile() const override
 		{
-			return std::string("");
+			return {};
 		}
 
 		std::string getAuthor() const override

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <utility>
 
 extern "C"
 {
@@ -399,7 +400,7 @@ protected:
 class LuaGameLogic : public FallbackGameLogic, public IScriptableComponent
 {
 	public:
-		LuaGameLogic(const std::string& file, DuelMatch* match, int score_to_win);
+		LuaGameLogic(std::string file, DuelMatch* match, int score_to_win);
 		~LuaGameLogic() override;
 
 		std::string getSourceFile() const override
@@ -452,8 +453,8 @@ class LuaGameLogic : public FallbackGameLogic, public IScriptableComponent
 };
 
 
-LuaGameLogic::LuaGameLogic( const std::string& filename, DuelMatch* match, int score_to_win ) :
-	FallbackGameLogic( score_to_win ), mSourceFile(filename)
+LuaGameLogic::LuaGameLogic( std::string filename, DuelMatch* match, int score_to_win ) :
+	FallbackGameLogic( score_to_win ), mSourceFile(std::move(filename))
 {
 	setMatch( match );
 	lua_pushlightuserdata(mState, this);

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -78,10 +78,7 @@ IGameLogic::IGameLogic( int stw )
 	mSquish[RIGHT_PLAYER] = 0;
 }
 
-IGameLogic::~IGameLogic()
-{
-	// nothing to do
-}
+IGameLogic::~IGameLogic() = default;
 
 int IGameLogic::getTouches(PlayerSide side) const
 {
@@ -330,35 +327,32 @@ class FallbackGameLogic : public IGameLogic
 		FallbackGameLogic( int stw ) : IGameLogic( stw )
 		{
 		}
-		virtual ~FallbackGameLogic()
-		{
+		~FallbackGameLogic() override = default;
 
-		}
-
-		virtual GameLogicPtr clone() const
+		GameLogicPtr clone() const override
 		{
 			return GameLogicPtr(new FallbackGameLogic( getScoreToWin() ));
 		}
 
-		virtual std::string getSourceFile() const
+		std::string getSourceFile() const override
 		{
 			return std::string("");
 		}
 
-		virtual std::string getAuthor() const
+		std::string getAuthor() const override
 		{
 			return "Blobby Volley 2 Developers";
 		}
 
 
-		virtual std::string getTitle() const
+		std::string getTitle() const override
 		{
 			return FALLBACK_RULES_NAME;
 		}
 
 protected:
 
-		virtual PlayerSide checkWin() const
+		PlayerSide checkWin() const override
 		{
 			int left = getScore(LEFT_PLAYER);
 			int right = getScore(RIGHT_PLAYER);
@@ -376,7 +370,7 @@ protected:
 			return NO_PLAYER;
 		}
 
-		virtual void OnBallHitsPlayerHandler(PlayerSide side)
+		void OnBallHitsPlayerHandler(PlayerSide side) override
 		{
 			if (getTouches(side) > 3)
 			{
@@ -385,20 +379,20 @@ protected:
 			}
 		}
 
-		virtual void OnBallHitsGroundHandler(PlayerSide side)
+		void OnBallHitsGroundHandler(PlayerSide side) override
 		{
 			score( other_side(side), 1 );
 			onError( side, other_side(side) );
 		}
 
-		virtual PlayerInput handleInput(PlayerInput ip, PlayerSide player)
+		PlayerInput handleInput(PlayerInput ip, PlayerSide player) override
 		{
 			return ip;
 		}
 
-		virtual void OnBallHitsWallHandler(PlayerSide side)		{ };
-		virtual void OnBallHitsNetHandler(PlayerSide side)		{ };
-		virtual void OnGameHandler( const DuelMatchState& state ) { };
+		void OnBallHitsWallHandler(PlayerSide side) override       { };
+		void OnBallHitsNetHandler(PlayerSide side) override	       { };
+		void OnGameHandler( const DuelMatchState& state ) override { };
 };
 
 
@@ -406,24 +400,24 @@ class LuaGameLogic : public FallbackGameLogic, public IScriptableComponent
 {
 	public:
 		LuaGameLogic(const std::string& file, DuelMatch* match, int score_to_win);
-		virtual ~LuaGameLogic();
+		~LuaGameLogic() override;
 
-		virtual std::string getSourceFile() const
+		std::string getSourceFile() const override
 		{
 			return mSourceFile;
 		}
 
-		virtual GameLogicPtr clone() const
+		GameLogicPtr clone() const override
 		{
 			return GameLogicPtr(new LuaGameLogic(mSourceFile, getMatch(), getScoreToWin()));
 		}
 
-		virtual std::string getAuthor() const
+		std::string getAuthor() const override
 		{
 			return mAuthor;
 		}
 
-		virtual std::string getTitle() const
+		std::string getTitle() const override
 		{
 			return mTitle;
 		}
@@ -431,13 +425,13 @@ class LuaGameLogic : public FallbackGameLogic, public IScriptableComponent
 
 	protected:
 
-		virtual PlayerInput handleInput(PlayerInput ip, PlayerSide player);
-		virtual PlayerSide checkWin() const;
-		virtual void OnBallHitsPlayerHandler(PlayerSide side);
-		virtual void OnBallHitsWallHandler(PlayerSide side);
-		virtual void OnBallHitsNetHandler(PlayerSide side);
-		virtual void OnBallHitsGroundHandler(PlayerSide side);
-		virtual void OnGameHandler( const DuelMatchState& state );
+		PlayerInput handleInput(PlayerInput ip, PlayerSide player) override;
+		PlayerSide checkWin() const override;
+		void OnBallHitsPlayerHandler(PlayerSide side) override;
+		void OnBallHitsWallHandler(PlayerSide side) override;
+		void OnBallHitsNetHandler(PlayerSide side) override;
+		void OnBallHitsGroundHandler(PlayerSide side) override;
+		void OnGameHandler( const DuelMatchState& state ) override;
 
 		static LuaGameLogic* getGameLogic(lua_State* state);
 
@@ -502,9 +496,7 @@ LuaGameLogic::LuaGameLogic( const std::string& filename, DuelMatch* match, int s
 	std::cout << "loaded rules "<< getTitle()<< " by " << getAuthor() << " from " << mSourceFile << std::endl;
 }
 
-LuaGameLogic::~LuaGameLogic()
-{
-}
+LuaGameLogic::~LuaGameLogic() = default;
 
 PlayerSide LuaGameLogic::checkWin() const
 {
@@ -520,7 +512,7 @@ PlayerSide LuaGameLogic::checkWin() const
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 
 	won = lua_toboolean(mState, -1);
 	lua_pop(mState, 1);
@@ -551,7 +543,7 @@ PlayerInput LuaGameLogic::handleInput(PlayerInput ip, PlayerSide player)
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 
 	PlayerInput ret;
 	ret.up = lua_toboolean(mState, -1);
@@ -576,7 +568,7 @@ void LuaGameLogic::OnBallHitsPlayerHandler(PlayerSide side)
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 }
 
 void LuaGameLogic::OnBallHitsWallHandler(PlayerSide side)
@@ -592,7 +584,7 @@ void LuaGameLogic::OnBallHitsWallHandler(PlayerSide side)
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 }
 
 void LuaGameLogic::OnBallHitsNetHandler(PlayerSide side)
@@ -609,7 +601,7 @@ void LuaGameLogic::OnBallHitsNetHandler(PlayerSide side)
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 }
 
 void LuaGameLogic::OnBallHitsGroundHandler(PlayerSide side)
@@ -626,7 +618,7 @@ void LuaGameLogic::OnBallHitsGroundHandler(PlayerSide side)
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 }
 
 void LuaGameLogic::OnGameHandler( const DuelMatchState& state )
@@ -640,7 +632,7 @@ void LuaGameLogic::OnGameHandler( const DuelMatchState& state )
 	{
 		std::cerr << "Lua Error: " << lua_tostring(mState, -1);
 		std::cerr << std::endl;
-	};
+	}
 }
 
 LuaGameLogic* LuaGameLogic::getGameLogic(lua_State* state)

--- a/src/GameLogicState.cpp
+++ b/src/GameLogicState.cpp
@@ -50,7 +50,7 @@ void GameLogicState::swapSides()
 	{
 		servingPlayer = RIGHT_PLAYER;
 	}
-	 else if(servingPlayer == RIGHT_PLAYER)
+	else if(servingPlayer == RIGHT_PLAYER)
 	{
 		servingPlayer = LEFT_PLAYER;
 	}

--- a/src/GenericIO.cpp
+++ b/src/GenericIO.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <cstring>
 #include <ostream>
+#include <utility>
 
 #include "raknet/BitStream.h"
 #include "raknet/NetworkTypes.h"
@@ -37,7 +38,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 class FileOut : public GenericOut
 {
 	public:
-		explicit FileOut(std::shared_ptr<FileWrite> file) : mFile(file)
+		explicit FileOut(std::shared_ptr<FileWrite> file) : mFile(std::move(file))
 		{
 
 		}
@@ -95,7 +96,7 @@ class FileOut : public GenericOut
 class FileIn : public GenericIn
 {
 	public:
-		explicit FileIn(std::shared_ptr<FileRead> file) : mFile(file)
+		explicit FileIn(std::shared_ptr<FileRead> file) : mFile(std::move(file))
 		{
 
 		}
@@ -347,7 +348,7 @@ class StreamOut : public GenericOut
 
 std::shared_ptr< GenericOut > createGenericWriter(std::shared_ptr<FileWrite> file)
 {
-	return std::make_shared< FileOut > (file);
+	return std::make_shared< FileOut > (std::move(file));
 }
 
 std::shared_ptr< GenericOut > createGenericWriter(RakNet::BitStream* stream)
@@ -362,7 +363,7 @@ std::shared_ptr< GenericOut > createGenericWriter(std::ostream& stream)
 
 std::shared_ptr< GenericIn > createGenericReader(std::shared_ptr<FileRead> file)
 {
-	return std::make_shared< FileIn > (file);
+	return std::make_shared< FileIn > (std::move(file));
 }
 
 std::shared_ptr< GenericIn > createGenericReader(RakNet::BitStream* stream)

--- a/src/GenericIO.cpp
+++ b/src/GenericIO.cpp
@@ -43,44 +43,44 @@ class FileOut : public GenericOut
 		}
 
 	private:
-		virtual void byte(const unsigned char& data) override
+		void byte(const unsigned char& data) override
 		{
 			mFile->writeByte(data);
 		}
 
-		virtual void boolean(const bool& data) override
+		void boolean(const bool& data) override
 		{
 			mFile->writeByte(data);
 		}
 
-		virtual void uint32(const unsigned int& data) override
+		void uint32(const unsigned int& data) override
 		{
 			mFile->writeUInt32(data);
 		}
 
-		virtual void number(const float& data) override
+		void number(const float& data) override
 		{
 			mFile->writeFloat(data);
 		}
 
-		virtual void string(const std::string& string) override
+		void string(const std::string& string) override
 		{
 			uint32(string.size());
 			mFile->write(string.data(), string.size());
 		}
 
 
-		virtual unsigned int tell() const override
+		unsigned int tell() const override
 		{
 			return mFile->tell();
 		}
 
-		virtual void seek(unsigned int pos) const override
+		void seek(unsigned int pos) const override
 		{
 			mFile->seek(pos);
 		}
 
-		virtual void array(const char* data, unsigned int length) override
+		void array(const char* data, unsigned int length) override
 		{
 			mFile->write(data, length);
 		}
@@ -101,27 +101,27 @@ class FileIn : public GenericIn
 		}
 
 	private:
-		virtual void byte(unsigned char& data) override
+		void byte(unsigned char& data) override
 		{
 			data = mFile->readByte();
 		}
 
-		virtual void boolean(bool& data) override
+		void boolean(bool& data) override
 		{
 			data = mFile->readByte();
 		}
 
-		virtual void uint32(unsigned int& data) override
+		void uint32(unsigned int& data) override
 		{
 			data = mFile->readUInt32();
 		}
 
-		virtual void number(float& data) override
+		void number(float& data) override
 		{
 			data = mFile->readFloat();
 		}
 
-		virtual void string(std::string& string) override
+		void string(std::string& string) override
 		{
 			/// \todo this might be bad performance wise
 			unsigned int ts;
@@ -137,17 +137,17 @@ class FileIn : public GenericIn
 		}
 
 
-		virtual unsigned int tell() const override
+		unsigned int tell() const override
 		{
 			return mFile->tell();
 		}
 
-		virtual void seek(unsigned int pos) const override
+		void seek(unsigned int pos) const override
 		{
 			mFile->seek(pos);
 		}
 
-		virtual void array(char* data, unsigned int length) override
+		void array(char* data, unsigned int length) override
 		{
 			mFile->readRawBytes(data, length);
 		}
@@ -169,44 +169,44 @@ class NetworkOut : public GenericOut
 		}
 
 	private:
-		virtual void byte(const unsigned char& data) override
+		void byte(const unsigned char& data) override
 		{
 			mStream->Write(data);
 		}
 
-		virtual void boolean(const bool& data) override
+		void boolean(const bool& data) override
 		{
 			mStream->Write(data);
 		}
 
-		virtual void uint32(const unsigned int& data) override
+		void uint32(const unsigned int& data) override
 		{
 			mStream->Write(data);
 		}
 
-		virtual void number(const float& data) override
+		void number(const float& data) override
 		{
 			mStream->Write(data);
 		}
 
-		virtual void string(const std::string& string) override
+		void string(const std::string& string) override
 		{
 			uint32(string.size());
 			mStream->Write(string.c_str(), string.size());
 		}
 
 
-		virtual unsigned int tell() const override
+		unsigned int tell() const override
 		{
 			return mStream->GetNumberOfBitsUsed();
 		}
 
-		virtual void seek(unsigned int pos) const override
+		void seek(unsigned int pos) const override
 		{
 			mStream->SetWriteOffset(pos);
 		}
 
-		virtual void array(const char* data, unsigned int length) override
+		void array(const char* data, unsigned int length) override
 		{
 			mStream->Write(data, length);
 		}
@@ -227,27 +227,27 @@ class NetworkIn : public GenericIn
 		}
 
 	private:
-		virtual void byte(unsigned char& data) override
+		void byte(unsigned char& data) override
 		{
 			mStream->Read(data);
 		}
 
-		virtual void boolean(bool& data) override
+		void boolean(bool& data) override
 		{
 			mStream->Read(data);
 		}
 
-		virtual void uint32( unsigned int& data) override
+		void uint32( unsigned int& data) override
 		{
 			mStream->Read(data);
 		}
 
-		virtual void number( float& data) override
+		void number( float& data) override
 		{
 			mStream->Read(data);
 		}
 
-		virtual void string( std::string& string) override
+		void string( std::string& string) override
 		{
 			/// \todo this might be bad performance wise
 			unsigned int ts;
@@ -263,18 +263,18 @@ class NetworkIn : public GenericIn
 		}
 
 
-		virtual unsigned int tell() const
+		unsigned int tell() const override
 		{
 			return mStream->GetReadOffset();
 		}
 
-		virtual void seek(unsigned int pos) const
+		void seek(unsigned int pos) const override
 		{
 			mStream->ResetReadPointer();
 			mStream->IgnoreBits(pos);
 		}
 
-		virtual void array( char* data, unsigned int length)
+		void array( char* data, unsigned int length) override
 		{
 			mStream->Read(data, length);
 		}
@@ -295,42 +295,42 @@ class StreamOut : public GenericOut
 		}
 
 	private:
-		virtual void byte(const unsigned char& data) override
+		void byte(const unsigned char& data) override
 		{
 			mStream << data << "\n";
 		}
 
-		virtual void boolean(const bool& data) override
+		void boolean(const bool& data) override
 		{
 			mStream << data << "\n";
 		}
 
-		virtual void uint32(const unsigned int& data) override
+		void uint32(const unsigned int& data) override
 		{
 			mStream << data << "\n";
 		}
 
-		virtual void number(const float& data) override
+		void number(const float& data) override
 		{
 			mStream << data << "\n";
 		}
 
-		virtual void string(const std::string& string) override
+		void string(const std::string& string) override
 		{
 			mStream << string << "\n";
 		}
 
 		/// currently not supported by StreamOut
-		virtual unsigned int tell() const override
+		unsigned int tell() const override
 		{
 			return -1;
 		}
 
-		virtual void seek(unsigned int pos) const override
+		void seek(unsigned int pos) const override
 		{
 		}
 
-		virtual void array(const char* data, unsigned int length) override
+		void array(const char* data, unsigned int length) override
 		{
 			std::string stringed(data, length);
 			mStream << stringed << "\n";

--- a/src/GenericIO.cpp
+++ b/src/GenericIO.cpp
@@ -37,7 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 class FileOut : public GenericOut
 {
 	public:
-		FileOut(std::shared_ptr<FileWrite> file) : mFile(file)
+		explicit FileOut(std::shared_ptr<FileWrite> file) : mFile(file)
 		{
 
 		}
@@ -95,7 +95,7 @@ class FileOut : public GenericOut
 class FileIn : public GenericIn
 {
 	public:
-		FileIn(std::shared_ptr<FileRead> file) : mFile(file)
+		explicit FileIn(std::shared_ptr<FileRead> file) : mFile(file)
 		{
 
 		}
@@ -163,7 +163,7 @@ class FileIn : public GenericIn
 class NetworkOut : public GenericOut
 {
 	public:
-		NetworkOut(RakNet::BitStream* stream) : mStream(stream)
+		explicit NetworkOut(RakNet::BitStream* stream) : mStream(stream)
 		{
 
 		}
@@ -221,7 +221,7 @@ class NetworkOut : public GenericOut
 class NetworkIn : public GenericIn
 {
 	public:
-		NetworkIn(RakNet::BitStream* stream) : mStream(stream)
+		explicit NetworkIn(RakNet::BitStream* stream) : mStream(stream)
 		{
 
 		}
@@ -289,7 +289,7 @@ class NetworkIn : public GenericIn
 class StreamOut : public GenericOut
 {
 	public:
-		StreamOut(std::ostream& stream) : mStream(stream)
+		explicit StreamOut(std::ostream& stream) : mStream(stream)
 		{
 
 		}

--- a/src/Global.h
+++ b/src/Global.h
@@ -33,18 +33,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // Detect wheather we have a desktop or mobile target
 #if (defined __ANDROID__) || (defined __APPLE__ && TARGET_OS_IPHONE) || (defined __APPLE__ && TARGET_OS_SIMULATOR) || (defined __SWITCH__)
-#define __MOBILE__ true
-#define __DESKTOP__ false
+#define BLOBBY_ON_MOBILE true
+#define BLOBBY_ON_DESKTOP false
 #else
-#define __MOBILE__ false
-#define __DESKTOP__ true
+#define BLOBBY_ON_MOBILE false
+#define BLOBBY_ON_DESKTOP true
 #endif
 
 // Detect features
 #if (defined __APPLE__ && TARGET_OS_IPHONE) || (defined __APPLE__ && TARGET_IPHONE_SIMULATOR)
-#define __FEATURE_HAS_BACKBUTTON__ false
+#define BLOBBY_FEATURE_HAS_BACKBUTTON false
 #else
-#define __FEATURE_HAS_BACKBUTTON__ true
+#define BLOBBY_FEATURE_HAS_BACKBUTTON true
 #endif
 
 /*!	\def DEBUG

--- a/src/Global.h
+++ b/src/Global.h
@@ -101,7 +101,7 @@ struct Color
 	{}
 
 	/// \sa toInt()
-	Color(unsigned int col)
+	explicit Color(unsigned int col)
 	: r(col&0xff)
 	, g((col>>8)&0xff)
 	, b((col>>16)&0xff)

--- a/src/Global.h
+++ b/src/Global.h
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <exception>
 #include <SDL2/SDL_stdinc.h>
 #include <cstring>
+#include <utility>
 
 // I hope the GP2X is the only combination of these systems
 #if defined(__linux__) && defined(__arm__)
@@ -147,7 +148,7 @@ struct Color
 struct ExtensionUnsupportedException : public std::exception
 {
 	std::string extension;
-	explicit ExtensionUnsupportedException(std::string name) : extension(name) {}
+	explicit ExtensionUnsupportedException(std::string name) : extension(std::move(name)) {}
 	~ExtensionUnsupportedException() noexcept override = default;
 };
 

--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -360,7 +360,7 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 			    (text == (TextManager::getSingleton())->getString(TextManager::LBL_NO)) ||
 			    (text == (TextManager::getSingleton())->getString(TextManager::MNU_LABEL_EXIT)))
 			{
-				//todo: Workarround to catch backkey
+				//todo: Workaround to catch backkey
 				clicked = true;
 				mActiveButton = id;
 			}

--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -523,7 +523,7 @@ bool IMGUI::doScrollbar(int id, const Vector2& position, float& value)
 		}
 	}
 
-	value = value > 0.0 ? (value < 1.0 ? value : 1.0) : 0.0;
+	value = value > 0.f ? (value < 1.f ? value : 1.f) : 0.f;
 	obj.pos2.x = value;
 
 	mLastWidget = id;

--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -203,7 +203,7 @@ void IMGUI::end()
 		}
 		mQueue->pop();
 	}
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 	if (mDrawCursor)
 	{
 		rmanager.drawImage("gfx/cursor.bmp", InputManager::getSingleton()->position() + Vector2(24.0, 24.0));
@@ -366,7 +366,7 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 			}
 		}
 
-		#if __MOBILE__
+		#if BLOBBY_ON_MOBILE
 			const int tolerance = 3;
 		#else
 			const int tolerance = 0;
@@ -379,7 +379,7 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 			mousepos.y - tolerance * 2 <= obj.pos1.y + fontSize)
 		{
 			obj.flags = obj.flags
-			#if __DESKTOP__
+			#if BLOBBY_ON_DESKTOP
 				| TF_HIGHLIGHT
 			#endif
 			;
@@ -489,7 +489,7 @@ bool IMGUI::doScrollbar(int id, const Vector2& position, float& value)
 			}
 		}
 
-		#if __MOBILE__
+		#if BLOBBY_ON_MOBILE
 			const int tolerance = 3;
 		#else
 			const int tolerance = 0;

--- a/src/IScriptableComponent.cpp
+++ b/src/IScriptableComponent.cpp
@@ -33,7 +33,7 @@ IScriptableComponent::~IScriptableComponent()
 	lua_close(mState);
 }
 
-void IScriptableComponent::openScript(std::string file)
+void IScriptableComponent::openScript(const std::string& file)
 {
 	int error = FileRead::readLuaScript(file, mState);
 	if (error == 0)

--- a/src/IScriptableComponent.cpp
+++ b/src/IScriptableComponent.cpp
@@ -123,7 +123,7 @@ int lua_pushvector(lua_State* state, const Vector2& v, VectorType type)
 		lua_pushnumber( state, v.x );
 		lua_pushnumber( state, -v.y );
 	}
-	 else if ( type == VectorType::POSITION )
+	else if ( type == VectorType::POSITION )
 	{
 		lua_pushnumber( state, v.x );
 		lua_pushnumber( state, 600 - v.y );
@@ -153,8 +153,8 @@ struct IScriptableComponent::Access
 	}
 };
 
-inline DuelMatch* getMatch( lua_State* s )  { return IScriptableComponent::Access::getMatch(s); };
-inline PhysicWorld* getWorld( lua_State* s )  { return IScriptableComponent::Access::getWorld(s); };
+inline DuelMatch* getMatch( lua_State* s )  { return IScriptableComponent::Access::getMatch(s); }
+inline PhysicWorld* getWorld( lua_State* s )  { return IScriptableComponent::Access::getWorld(s); }
 
 // standard lua functions
 int get_ball_pos(lua_State* state)

--- a/src/IScriptableComponent.h
+++ b/src/IScriptableComponent.h
@@ -39,7 +39,7 @@ protected:
 	IScriptableComponent();
 	virtual ~IScriptableComponent();
 
-	void openScript(std::string file);
+	void openScript(const std::string& file);
 	void setLuaGlobal(const char* name, double value);
 	bool getLuaFunction(const char* name) const;
 

--- a/src/InputDevice.h
+++ b/src/InputDevice.h
@@ -30,8 +30,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 class InputDevice : public ObjectCounter<InputDevice>
 {
 	public:
-		InputDevice() {}
-		virtual ~InputDevice() {}
+		InputDevice() = default;
+		virtual ~InputDevice() = default;
 
 		virtual PlayerInputAbs transferInput() = 0;
 };

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -216,7 +216,7 @@ void InputManager::updateInput()
 				break;
 			// Workarround because SDL has a bug in Version 2.0.1,
 			// so that we can't use mouse here
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 			case SDL_MOUSEBUTTONDOWN:
 				mLastMouseButton = event.button.button;
 				switch (event.button.button)
@@ -233,7 +233,7 @@ void InputManager::updateInput()
 						break;
 				}
 				break;
-#elif __MOBILE__
+#elif BLOBBY_ON_MOBILE
 			case SDL_FINGERDOWN:
 				mClick = true;
 

--- a/src/InputSourceFactory.cpp
+++ b/src/InputSourceFactory.cpp
@@ -28,21 +28,21 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "LocalInputSource.h"
 #include "ScriptedInputSource.h"
 
-std::shared_ptr<InputSource> InputSourceFactory::createInputSource( std::shared_ptr<IUserConfigReader> config, PlayerSide side )
+std::shared_ptr<InputSource> InputSourceFactory::createInputSource( IUserConfigReader& config, PlayerSide side )
 {
 	std::string prefix = side == LEFT_PLAYER ? "left" : "right";
 	try
 	{
 		// these operations may throw, i.e., when the script is not found (should not happen)
 		//  or has errors
-		if (config->getBool(prefix + "_player_human"))
+		if (config.getBool(prefix + "_player_human"))
 		{
 			return std::make_shared<LocalInputSource>(side);
 		}
 		else
 		{
-			return std::make_shared<ScriptedInputSource>("scripts/" + config->getString(prefix + "_script_name"),
-					side, config->getInteger(prefix + "_script_strength"));
+			return std::make_shared<ScriptedInputSource>("scripts/" + config.getString(prefix + "_script_name"),
+					side, config.getInteger(prefix + "_script_strength"));
 		}
 	} catch (std::exception& e)
 	{

--- a/src/InputSourceFactory.h
+++ b/src/InputSourceFactory.h
@@ -30,5 +30,5 @@ class InputSource;
 class InputSourceFactory
 {
 	public:
-		static std::shared_ptr<InputSource> createInputSource( std::shared_ptr<IUserConfigReader> config, PlayerSide pls );
+		static std::shared_ptr<InputSource> createInputSource(IUserConfigReader& config, PlayerSide pls );
 };

--- a/src/LocalInputSource.h
+++ b/src/LocalInputSource.h
@@ -28,7 +28,7 @@ class InputDevice;
 class LocalInputSource : public InputSource
 {
 	public:
-		LocalInputSource(PlayerSide player);
+		explicit LocalInputSource(PlayerSide player);
 		~LocalInputSource() override;
 
 		PlayerInputAbs getNextInput() override;

--- a/src/LocalInputSource.h
+++ b/src/LocalInputSource.h
@@ -29,9 +29,9 @@ class LocalInputSource : public InputSource
 {
 	public:
 		LocalInputSource(PlayerSide player);
-		~LocalInputSource();
+		~LocalInputSource() override;
 
-		virtual PlayerInputAbs getNextInput();
+		PlayerInputAbs getNextInput() override;
 
 	private:
 		InputDevice* mInputDevice;

--- a/src/PhysicWorld.cpp
+++ b/src/PhysicWorld.cpp
@@ -22,6 +22,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "PhysicWorld.h"
 
 /* includes */
+#include <utility>
+
 #include "GameConstants.h"
 #include "MatchEvents.h"
 
@@ -399,7 +401,7 @@ void PhysicWorld::setState(const PhysicState& ps)
 
 void PhysicWorld::setEventCallback( event_callback_fn cb )
 {
-	mCallback = cb;
+	mCallback = std::move(cb);
 }
 
 inline short set_fpu_single_precision()

--- a/src/PhysicWorld.cpp
+++ b/src/PhysicWorld.cpp
@@ -196,8 +196,8 @@ bool PhysicWorld::handleBlobbyBallCollision(PlayerSide player)
 	// ok, if we get here, there actually was a collision
 
 	// calculate hit intensity
-	mLastHitIntensity = Vector2(mBallVelocity, mBlobVelocity[player]).length() / 25.0;
-	mLastHitIntensity = mLastHitIntensity > 1.0 ? 1.0 : mLastHitIntensity;
+	mLastHitIntensity = Vector2(mBallVelocity, mBlobVelocity[player]).length() / 25.f;
+	mLastHitIntensity = mLastHitIntensity > 1.f ? 1.f : mLastHitIntensity;
 
 	// set ball velocity
 	mBallVelocity = -Vector2(mBallPosition, circlepos);
@@ -262,9 +262,9 @@ void PhysicWorld::step(const PlayerInput& leftInput, const PlayerInput& rightInp
 
 	// Overflow-Protection
 	if (mBallRotation <= 0)
-		mBallRotation = 6.25 + mBallRotation;
-	else if (mBallRotation >= 6.25)
-		mBallRotation = mBallRotation - 6.25;
+		mBallRotation = 6.25f + mBallRotation;
+	else if (mBallRotation >= 6.25f)
+		mBallRotation = mBallRotation - 6.25f;
 
 
 	reset_fpu_flags(fpf);

--- a/src/PlayerIdentity.cpp
+++ b/src/PlayerIdentity.cpp
@@ -1,7 +1,8 @@
 #include "PlayerIdentity.h"
 
-PlayerIdentity::PlayerIdentity(std::string name) : mName(name),
-																	mOscillating(false)
+#include <utility>
+
+PlayerIdentity::PlayerIdentity(std::string name) : mName(std::move(name)), mOscillating(false)
 {
 
 }

--- a/src/PlayerIdentity.cpp
+++ b/src/PlayerIdentity.cpp
@@ -7,15 +7,13 @@ PlayerIdentity::PlayerIdentity(std::string name) : mName(std::move(name)), mOsci
 
 }
 
-PlayerIdentity::PlayerIdentity(const std::string& name, Color color, bool osci, PlayerSide side) : mName(name),
+PlayerIdentity::PlayerIdentity(std::string name, Color color, bool osci, PlayerSide side) : mName(std::move(name)),
 																	mStaticColor(color),
 																	mOscillating(osci),
 																	mPreferredSide(side)
 {
 
 }
-
-PlayerIdentity::~PlayerIdentity() = default;
 
 const std::string& PlayerIdentity::getName() const
 {

--- a/src/PlayerIdentity.h
+++ b/src/PlayerIdentity.h
@@ -28,7 +28,7 @@ class PlayerIdentity
 {
 	public:
 		PlayerIdentity() = default;
-		PlayerIdentity(std::string name);
+		explicit PlayerIdentity(std::string name);
 		PlayerIdentity(const std::string& name, Color color, bool osci, PlayerSide pref);
 		~PlayerIdentity();
 

--- a/src/PlayerIdentity.h
+++ b/src/PlayerIdentity.h
@@ -29,8 +29,7 @@ class PlayerIdentity
 	public:
 		PlayerIdentity() = default;
 		explicit PlayerIdentity(std::string name);
-		PlayerIdentity(const std::string& name, Color color, bool osci, PlayerSide pref);
-		~PlayerIdentity();
+		PlayerIdentity(std::string name, Color color, bool osci, PlayerSide pref);
 
 		const std::string& getName() const;
 		Color getStaticColor() const;

--- a/src/PlayerIdentity.h
+++ b/src/PlayerIdentity.h
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 class PlayerIdentity
 {
 	public:
-		PlayerIdentity() {};
+		PlayerIdentity() = default;
 		PlayerIdentity(std::string name);
 		PlayerIdentity(const std::string& name, Color color, bool osci, PlayerSide pref);
 		~PlayerIdentity();

--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -290,10 +290,10 @@ SDL_Rect RenderManager::ballRect(const Vector2& position)
 
 Vector2 RenderManager::ballShadowPosition(const Vector2& position)
 {
-	return Vector2(
+	return {
 		position.x + (500.f - position.y) / 4.f + 16.f,
 		500.f - (500.f - position.y) / 16.f - 10.f
-	);
+	};
 }
 
 SDL_Rect RenderManager::ballShadowRect(const Vector2& position)
@@ -310,10 +310,10 @@ SDL_Rect RenderManager::ballShadowRect(const Vector2& position)
 
 Vector2 RenderManager::blobShadowPosition(const Vector2& position)
 {
-	return Vector2(
+	return {
 		position.x + (500.f - position.y) / 4 + 16.f,
 		500.f - (500.f - position.y) / 16.f - 10.f
-	);
+	};
 }
 
 SDL_Rect RenderManager::blobShadowRect(const Vector2& position)
@@ -351,9 +351,9 @@ Color RenderManager::getOscillationColor() const
 {
 	float time = float(SDL_GetTicks()) / 1000.f;
 
-	return Color(
+	return {
 		int((std::sin(time*1.5) + 1.0) * 128),
 		int((std::sin(time*2.5) + 1.0) * 128),
 		int((std::sin(time*3.5) + 1.0) * 128)
-	);
+	};
 }

--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -82,7 +82,7 @@ SDL_Surface* RenderManager::highlightSurface(SDL_Surface* surface, int luminance
 	return newSurface;
 }
 
-SDL_Surface* RenderManager::loadSurface(std::string filename)
+SDL_Surface* RenderManager::loadSurface(const std::string& filename)
 {
 	FileRead file(filename);
 	int fileLength = file.length();

--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -291,8 +291,8 @@ SDL_Rect RenderManager::ballRect(const Vector2& position)
 Vector2 RenderManager::ballShadowPosition(const Vector2& position)
 {
 	return Vector2(
-		position.x + (500.0 - position.y) / 4 + 16.0,
-		500.0 - (500.0 - position.y) / 16.0 - 10.0
+		position.x + (500.f - position.y) / 4.f + 16.f,
+		500.f - (500.f - position.y) / 16.f - 10.f
 	);
 }
 
@@ -311,8 +311,8 @@ SDL_Rect RenderManager::ballShadowRect(const Vector2& position)
 Vector2 RenderManager::blobShadowPosition(const Vector2& position)
 {
 	return Vector2(
-		position.x + (500.0 - position.y) / 4 + 16.0,
-		500.0 - (500.0 - position.y) / 16.0 - 10.0
+		position.x + (500.f - position.y) / 4 + 16.f,
+		500.f - (500.f - position.y) / 16.f - 10.f
 	);
 }
 
@@ -349,7 +349,7 @@ SDL_Window* RenderManager::getWindow()
 
 Color RenderManager::getOscillationColor() const
 {
-	float time = float(SDL_GetTicks()) / 1000.0;
+	float time = float(SDL_GetTicks()) / 1000.f;
 
 	return Color(
 		int((std::sin(time*1.5) + 1.0) * 128),

--- a/src/RenderManager.h
+++ b/src/RenderManager.h
@@ -101,7 +101,7 @@ struct BufferedImage : public ObjectCounter<BufferedImage>
 class RenderManager : public ObjectCounter<RenderManager>
 {
 	public:
-		virtual ~RenderManager(){};
+		virtual ~RenderManager() = default;
 
 		static RenderManager* createRenderManagerSDL();
 		//static RenderManager* createRenderManagerGP2X();

--- a/src/RenderManager.h
+++ b/src/RenderManager.h
@@ -190,7 +190,7 @@ class RenderManager : public ObjectCounter<RenderManager>
 		// Returns index for ? on unknown char
 		int getNextFontIndex(std::string::const_iterator& iter);
 		SDL_Surface* highlightSurface(SDL_Surface* surface, int luminance);
-		SDL_Surface* loadSurface(std::string filename);
+		SDL_Surface* loadSurface(const std::string& filename);
 		SDL_Surface* createEmptySurface(unsigned int width, unsigned int height);
 
 		SDL_Window* mWindow;

--- a/src/RenderManagerGL2D.cpp
+++ b/src/RenderManagerGL2D.cpp
@@ -337,11 +337,9 @@ void RenderManagerGL2D::deinit()
 	glDeleteTextures(1/*mFont.size()*/, &mFont[0].texture);
 	glDeleteTextures(/*mHighlightFont.size()*/1, &mHighlightFont[0].texture);
 
-	for (std::map<std::string, BufferedImage*>::iterator iter = mImageMap.begin();
-		iter != mImageMap.end(); ++iter)
-	{
-		glDeleteTextures(1, &(*iter).second->glHandle);
-		delete iter->second;
+	for (auto& iter : mImageMap) {
+		glDeleteTextures(1, &iter.second->glHandle);
+		delete iter.second;
 	}
 
 	glDeleteTextures(1, &mParticle);

--- a/src/RenderManagerGL2D.cpp
+++ b/src/RenderManagerGL2D.cpp
@@ -115,7 +115,7 @@ GLuint RenderManagerGL2D::loadTexture(SDL_Surface *surface, bool specular)
 #else
 			0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
 #endif
-	SDL_BlitSurface(textureSurface, 0, convertedTexture, &targetRect);
+	SDL_BlitSurface(textureSurface, nullptr, convertedTexture, &targetRect);
 
 	if (specular)
 	{
@@ -195,10 +195,7 @@ void RenderManagerGL2D::drawQuad(float x, float y, const Texture& tex) {
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 }
 
-RenderManagerGL2D::RenderManagerGL2D()
-	: RenderManager()
-{
-}
+RenderManagerGL2D::RenderManagerGL2D() = default;
 
 RenderManager* RenderManager::createRenderManagerGL2D()
 {
@@ -293,8 +290,8 @@ void RenderManagerGL2D::init(int xResolution, int yResolution, bool fullscreen)
 		SDL_Surface* highlight = highlightSurface(fontSurface, 60);
 
 		SDL_Rect r = {(Uint16)x, 0, (Uint16)fontSurface->w, (Uint16)fontSurface->h};
-		SDL_BlitSurface(fontSurface, 0, textbase, &r);
-		SDL_BlitSurface(highlight, 0, hltextbase, &r);
+		SDL_BlitSurface(fontSurface, nullptr, textbase, &r);
+		SDL_BlitSurface(highlight, nullptr, hltextbase, &r);
 		r.x = sx;
 		r.y = 0;
 		Texture s = Texture(0, x, 0, fontSurface->w, fontSurface->h, 2048, 32);

--- a/src/RenderManagerGL2D.cpp
+++ b/src/RenderManagerGL2D.cpp
@@ -668,13 +668,13 @@ void RenderManagerGL2D::drawParticle(const Vector2& pos, int player)
 	float w = 16.0;
 	float h = 16.0;
 	glTexCoord2f(0.0, 0.0);
-	glVertex2f(pos.x - w / 2.0, pos.y - h / 2.0);
+	glVertex2f(pos.x - w / 2.f, pos.y - h / 2.f);
 	glTexCoord2f(1.0, 0.0);
-	glVertex2f(pos.x + w / 2.0, pos.y - h / 2.0);
+	glVertex2f(pos.x + w / 2.f, pos.y - h / 2.f);
 	glTexCoord2f(1.0, 1.0);
-	glVertex2f(pos.x + w / 2.0, pos.y + h / 2.0);
+	glVertex2f(pos.x + w / 2.f, pos.y + h / 2.f);
 	glTexCoord2f(0.0, 1.0);
-	glVertex2f(pos.x - w / 2.0, pos.y + h / 2.0);
+	glVertex2f(pos.x - w / 2.f, pos.y + h / 2.f);
 }
 
 void RenderManagerGL2D::endDrawParticles()

--- a/src/RenderManagerSDL.cpp
+++ b/src/RenderManagerSDL.cpp
@@ -92,7 +92,6 @@ SDL_Surface* RenderManagerSDL::colorSurface(SDL_Surface *surface, Color color)
 }
 
 RenderManagerSDL::RenderManagerSDL()
-	: RenderManager()
 {
 	mBallRotation = 0.0;
 	mLeftBlobAnimationState = 0.0;
@@ -257,9 +256,9 @@ void RenderManagerSDL::init(int xResolution, int yResolution, bool fullscreen)
 		SDL_SetTextureBlendMode(leftBlobTex, SDL_BLENDMODE_BLEND);
 		SDL_UpdateTexture(leftBlobTex, nullptr, formatedBlobImage->pixels, formatedBlobImage->pitch);
 
-		mLeftBlob.push_back(DynamicColoredTexture(
+		mLeftBlob.emplace_back(
 				leftBlobTex,
-				Color(255, 255, 255)));
+				Color(255, 255, 255));
 
 		SDL_Texture* rightBlobTex = SDL_CreateTexture(mRenderer,
 				SDL_PIXELFORMAT_ABGR8888,
@@ -268,9 +267,9 @@ void RenderManagerSDL::init(int xResolution, int yResolution, bool fullscreen)
 		SDL_SetTextureBlendMode(rightBlobTex, SDL_BLENDMODE_BLEND);
 		SDL_UpdateTexture(rightBlobTex, nullptr, formatedBlobImage->pixels, formatedBlobImage->pitch);
 
-		mRightBlob.push_back(DynamicColoredTexture(
+		mRightBlob.emplace_back(
 				rightBlobTex,
-				Color(255, 255, 255)));
+				Color(255, 255, 255));
 
 		// Prepare blobby shadow textures
 		SDL_Texture* leftBlobShadowTex = SDL_CreateTexture(mRenderer,
@@ -278,9 +277,9 @@ void RenderManagerSDL::init(int xResolution, int yResolution, bool fullscreen)
 				SDL_TEXTUREACCESS_STREAMING,
 				formatedBlobShadowImage->w, formatedBlobShadowImage->h);
 		SDL_SetTextureBlendMode(leftBlobShadowTex, SDL_BLENDMODE_BLEND);
-		mLeftBlobShadow.push_back(DynamicColoredTexture(
+		mLeftBlobShadow.emplace_back(
 				leftBlobShadowTex,
-				Color(255, 255, 255)));
+				Color(255, 255, 255));
 		SDL_UpdateTexture(leftBlobShadowTex, nullptr, formatedBlobShadowImage->pixels, formatedBlobShadowImage->pitch);
 
 		SDL_Texture* rightBlobShadowTex = SDL_CreateTexture(mRenderer,
@@ -288,9 +287,9 @@ void RenderManagerSDL::init(int xResolution, int yResolution, bool fullscreen)
 				SDL_TEXTUREACCESS_STREAMING,
 				formatedBlobShadowImage->w, formatedBlobShadowImage->h);
 		SDL_SetTextureBlendMode(rightBlobShadowTex, SDL_BLENDMODE_BLEND);
-		mRightBlobShadow.push_back(DynamicColoredTexture(
+		mRightBlobShadow.emplace_back(
 				rightBlobShadowTex,
-				Color(255, 255, 255)));
+				Color(255, 255, 255));
 		SDL_UpdateTexture(rightBlobShadowTex, nullptr, formatedBlobShadowImage->pixels, formatedBlobShadowImage->pitch);
 
 		// Load specific icon to cancel a game

--- a/src/RenderManagerSDL.cpp
+++ b/src/RenderManagerSDL.cpp
@@ -293,7 +293,7 @@ void RenderManagerSDL::init(int xResolution, int yResolution, bool fullscreen)
 		SDL_UpdateTexture(rightBlobShadowTex, nullptr, formatedBlobShadowImage->pixels, formatedBlobShadowImage->pitch);
 
 		// Load specific icon to cancel a game
-#if !__FEATURE_HAS_BACKBUTTON__
+#if !BLOBBY_FEATURE_HAS_BACKBUTTON
 		tmpSurface = loadSurface("gfx/flag.bmp");
 		SDL_SetColorKey(tmpSurface, SDL_TRUE, SDL_MapRGB(tmpSurface->format, 0, 0, 0));
 		mBackFlag = SDL_CreateTextureFromSurface(mRenderer, tmpSurface);
@@ -394,7 +394,7 @@ void RenderManagerSDL::deinit()
 		SDL_DestroyTexture(mHighlightFont[i]);
 	}
 
-#if !__FEATURE_HAS_BACKBUTTON__
+#if !BLOBBY_FEATURE_HAS_BACKBUTTON
     SDL_DestroyTexture(mBackFlag);
 #endif
 
@@ -453,7 +453,7 @@ void RenderManagerSDL::draw()
 	rodPosition.h = 300;
 	SDL_RenderCopy(mRenderer, mBackground, &rodPosition, &rodPosition);
 
-#if !__FEATURE_HAS_BACKBUTTON__
+#if !BLOBBY_FEATURE_HAS_BACKBUTTON
 	position.x = 400 - 35;
 	position.y = 70;
 	position.w = 70;

--- a/src/RenderManagerSDL.h
+++ b/src/RenderManagerSDL.h
@@ -116,7 +116,7 @@ class RenderManagerSDL : public RenderManager
 		void drawTextImpl(const std::string& text, Vector2 position, unsigned int flags);
 		void colorizeBlobs(int player);
 
-#if !__FEATURE_HAS_BACKBUTTON__
+#if !BLOBBY_FEATURE_HAS_BACKBUTTON
         SDL_Texture* mBackFlag;
 #endif
 };

--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -82,9 +82,7 @@ ScriptedInputSource::ScriptedInputSource(const std::string& filename, PlayerSide
 	lua_pop(mState, lua_gettop(mState));
 }
 
-ScriptedInputSource::~ScriptedInputSource()
-{
-}
+ScriptedInputSource::~ScriptedInputSource() = default;
 
 PlayerInputAbs ScriptedInputSource::getNextInput()
 {
@@ -97,7 +95,7 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 	lua_pushboolean(mState, false);
 	lua_setglobal(mState, "__WANT_JUMP");
 
-	if (getMatch() == 0)
+	if (getMatch() == nullptr)
 	{
 		return PlayerInputAbs();
 	} else

--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -97,7 +97,7 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 
 	if (getMatch() == nullptr)
 	{
-		return PlayerInputAbs();
+		return {};
 	} else
 	{
 		IScriptableComponent::setMatch( const_cast<DuelMatch*>(getMatch()) );
@@ -131,7 +131,7 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 	}
 
 	if (mStartTime + WAITING_TIME > SDL_GetTicks() && serving)
-		return PlayerInputAbs();
+		return {};
 
 	// random jump delay depending on difficulty
 	if( wantjump && !mLastJump )
@@ -147,5 +147,5 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 
 	mLastJump = wantjump;
 
-	return PlayerInputAbs(wantleft, wantright, wantjump);
+	return {wantleft, wantright, wantjump};
 }

--- a/src/ScriptedInputSource.h
+++ b/src/ScriptedInputSource.h
@@ -54,9 +54,9 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 		/// with the given filename. The side parameter tells the script
 		/// which side is it on.
 		ScriptedInputSource(const std::string& filename, PlayerSide side, unsigned int difficulty);
-		~ScriptedInputSource();
+		~ScriptedInputSource() override;
 
-		virtual PlayerInputAbs getNextInput();
+		PlayerInputAbs getNextInput() override;
 		using InputSource::getMatch;
 
 	private:

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -132,7 +132,7 @@ bool SoundManager::init()
 	desiredSpec.callback = playCallback;
 	desiredSpec.userdata = mSingleton;
 
-	mAudioDevice = SDL_OpenAudioDevice(NULL, 0, &desiredSpec, &mAudioSpec, SDL_AUDIO_ALLOW_FORMAT_CHANGE);
+	mAudioDevice = SDL_OpenAudioDevice(nullptr, 0, &desiredSpec, &mAudioSpec, SDL_AUDIO_ALLOW_FORMAT_CHANGE);
 
 	if (desiredSpec.format != mAudioSpec.format)
 	{

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* implementation */
 SoundManager* SoundManager::mSingleton;
 
-Sound* SoundManager::loadSound(const std::string& filename)
+Sound* SoundManager::loadSound(const std::string& filename) const
 {
 	FileRead file(filename);
 	int fileLength = file.length();

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -183,16 +183,12 @@ void SoundManager::playCallback(void* singleton, Uint8* stream, int length)
 
 void SoundManager::deinit()
 {
-	for (std::map<std::string, Sound*>::iterator iter = mSound.begin();
-			iter != mSound.end(); ++iter)
+	for (auto& iter : mSound)
 	{
-		if (iter->second)
+		if (iter.second)
 		{
-			if (iter->second->data != 0)
-			{
-				delete[] iter->second->data;
-			}
-			delete iter->second;
+			delete[] iter.second->data;
+			delete iter.second;
 		}
 	}
 	SDL_UnlockAudioDevice(mAudioDevice);

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -109,7 +109,7 @@ bool SoundManager::playSound(const std::string& filename, float volume)
 		}
 		Sound soundInstance = Sound(*soundBuffer);
 		soundInstance.volume =
-			volume > 0.0 ? (volume < 1.0 ? volume : 1.0) : 0.0;
+			volume > 0.f ? (volume < 1.f ? volume : 1.f) : 0.f;
 		SDL_LockAudioDevice(mAudioDevice);
 		mPlayingSound.push_back(soundInstance);
 		SDL_UnlockAudioDevice(mAudioDevice);
@@ -225,7 +225,7 @@ SoundManager& SoundManager::getSingleton()
 
 void SoundManager::setVolume(float volume)
 {
-	volume = volume > 0.0 ? (volume < 1.0 ? volume : 1.0) : 0.0;
+	volume = volume > 0.f ? (volume < 1.f ? volume : 1.f) : 0.f;
 	mVolume = volume;
 }
 

--- a/src/SoundManager.h
+++ b/src/SoundManager.h
@@ -78,6 +78,6 @@ class SoundManager : public ObjectCounter<SoundManager>
 		float mVolume;
 		bool mMute;
 
-		Sound* loadSound(const std::string& filename);
+		Sound* loadSound(const std::string& filename) const;
 		static void playCallback(void* singleton, Uint8* stream, int length);
 };

--- a/src/TextManager.h
+++ b/src/TextManager.h
@@ -190,7 +190,7 @@ class TextManager
 
 	private:
 		/// private construktor, use createTextManager
-		TextManager(std::string l);
+		explicit TextManager(std::string l);
 
 		/// Singleton
 		static TextManager* mSingleton;

--- a/src/Vector.h
+++ b/src/Vector.h
@@ -62,7 +62,7 @@ class Vector2
 
 		inline Vector2 halfVector(const Vector2& vec) const
 		{
-			return Vector2(x + (vec.x - x) / 2, y + (vec.y - y) / 2);
+			return {x + (vec.x - x) / 2, y + (vec.y - y) / 2};
 		}
 
 		inline Vector2& operator = (const Vector2& newVector)
@@ -84,34 +84,34 @@ class Vector2
 
 		inline Vector2 operator + (const Vector2& vector) const
 		{
-			return Vector2(x + vector.x, y + vector.y);
+			return {x + vector.x, y + vector.y};
 		}
 
 		inline Vector2 operator - (const Vector2& vector) const
 		{
-			return Vector2(x - vector.x, y - vector.y);
+			return {x - vector.x, y - vector.y};
 		}
 
 		inline Vector2 operator * (float scalar) const
 		{
-			return Vector2(x * scalar, y * scalar);
+			return {x * scalar, y * scalar};
 		}
 
 		inline Vector2 operator * (const Vector2& vector) const
 		{
-			return Vector2(x * vector.x, y * vector.y);
+			return {x * vector.x, y * vector.y};
 		}
 
 		inline Vector2 operator / (float scalar) const
 		{
 			assert(scalar != 0.0);
-			float invert = 1.0 / scalar;
-			return Vector2(x * invert, y * invert);
+			float invert = 1.f / scalar;
+			return {x * invert, y * invert};
 		}
 
 		inline Vector2 operator - () const
 		{
-			return Vector2(-x, -y);
+			return {-x, -y};
 		}
 
 		inline Vector2& operator += (const Vector2& vector)
@@ -161,7 +161,7 @@ inline Vector2::Vector2() : x(0), y(0)
 {
 }
 
-inline Vector2::Vector2(float a, float b) : x(a), y(b)
+inline Vector2::Vector2(float x_, float y_) : x(x_), y(y_)
 {
 }
 
@@ -172,27 +172,27 @@ inline Vector2::Vector2(const Vector2& v1, const Vector2& v2) : x(v2.x - v1.x), 
 
 inline Vector2 Vector2::reflectX() const
 {
-	return Vector2(-x, y);
+	return {-x, y};
 }
 
 inline Vector2 Vector2::reflectY() const
 {
-	return Vector2(x, -y);
+	return {x, -y};
 }
 
 inline Vector2 Vector2::scale(float factor) const
 {
-	return Vector2(x * factor, y * factor);
+	return {x * factor, y * factor};
 }
 
 inline Vector2 Vector2::scaleX(float factor) const
 {
-	return Vector2(x * factor, y);
+	return {x * factor, y};
 }
 
 inline Vector2 Vector2::scaleY(float factor) const
 {
-	return Vector2(x, y * factor);
+	return {x, y * factor};
 }
 
 inline float Vector2::length() const
@@ -209,14 +209,14 @@ inline Vector2 Vector2::normalise()
 {
 	float fLength = length();
 	if (fLength > 1e-08)
-		return Vector2(x / fLength, y / fLength);
+		return {x / fLength, y / fLength};
 
 	return *this;
 }
 
 inline Vector2 Vector2::contraVector() const
 {
-	return Vector2(-x, -y);
+	return {-x, -y};
 }
 
 inline void Vector2::clear()

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -39,7 +39,7 @@ template< std::size_t N >
 constexpr std::size_t length( char const (&)[N] )
 {
 	return N-1;
-};
+}
 
 // checks whether a given character belongs to a valid base64 block
 constexpr bool is_valid( char c )

--- a/src/blobnet/adt/Queue.hpp
+++ b/src/blobnet/adt/Queue.hpp
@@ -17,8 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 =============================================================================*/
 
-#ifndef _QUEUE_HPP_
-#define _QUEUE_HPP_
+#ifndef QUEUE_HPP_
+#define QUEUE_HPP_
 
 /* Includes */
 #include <deque>

--- a/src/blobnet/adt/Queue.hpp
+++ b/src/blobnet/adt/Queue.hpp
@@ -90,13 +90,9 @@ namespace ADT {
 		ContainerType array;
 	};
 
-	template <class QueueType> Queue<QueueType>::Queue()
-	{
-	}
+	template <class QueueType> Queue<QueueType>::Queue() = default;
 
-	template <class QueueType> Queue<QueueType>::~Queue()
-	{
-	}
+	template <class QueueType> Queue<QueueType>::~Queue() = default;
 
 	template <class QueueType> Queue<QueueType>::Queue(const Queue& original_copy)
 	{

--- a/src/blobnet/exception/HttpException.hpp
+++ b/src/blobnet/exception/HttpException.hpp
@@ -33,7 +33,7 @@ namespace Exception {
 	public:
 		/// @brief constructor
 		/// @param message Message to describe the error
-		HttpException(const std::string& message) : std::runtime_error(message)
+		explicit HttpException(const std::string& message) : std::runtime_error(message)
 		{	
 		};
 	};

--- a/src/blobnet/exception/HttpException.hpp
+++ b/src/blobnet/exception/HttpException.hpp
@@ -17,8 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 =============================================================================*/
 
-#ifndef _BLOBNET_EXCEPTION_HTTPEXCEPTION_HPP_
-#define _BLOBNET_EXCEPTION_HTTPEXCEPTION_HPP_
+#ifndef BLOBNET_EXCEPTION_HTTPEXCEPTION_HPP_
+#define BLOBNET_EXCEPTION_HTTPEXCEPTION_HPP_
 
 /* Includes */
 #include <stdexcept>

--- a/src/blobnet/layer/Http.cpp
+++ b/src/blobnet/layer/Http.cpp
@@ -51,9 +51,7 @@ Http::Http(const std::string& hostname, const int& port)
 {
 }
 
-Http::~Http()
-{
-}
+Http::~Http() = default;
 
 
 void Http::request(const std::string& path, std::stringstream& response)
@@ -76,7 +74,7 @@ void Http::request(const std::string& path, std::stringstream& response)
 		if(mSocketLayer.Connect(inOutSocket, inet_addr(ipAddress), mPort) == -1)
 		{
 			throw Exception::HttpException("Can't connect to host.");
-		};
+		}
 
 		// Message for a simple request
 		std::string request = "GET /" + path + " HTTP/1.1\r\nHost: " + mHostname + "\r\n\r\n";

--- a/src/blobnet/layer/Http.cpp
+++ b/src/blobnet/layer/Http.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <utility>
 
 
 #if (defined _WIN32)
@@ -45,8 +46,8 @@ namespace Layer
 {
 
 /* implementation */
-Http::Http(const std::string& hostname, const int& port)
-: mHostname(hostname)
+Http::Http(std::string hostname, const int& port)
+: mHostname(std::move(hostname))
 , mPort(port)
 {
 }

--- a/src/blobnet/layer/Http.hpp
+++ b/src/blobnet/layer/Http.hpp
@@ -35,7 +35,7 @@ namespace Layer {
 	{
 	public:
 		/// @brief constructor, connects to an host
-		Http(const std::string& hostname, const int& port);
+		Http(std::string hostname, const int& port);
 
 		/// @brief deconstructor, closes connection to host
 		~Http();

--- a/src/blobnet/layer/Http.hpp
+++ b/src/blobnet/layer/Http.hpp
@@ -17,8 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 =============================================================================*/
 
-#ifndef _BLOBNET_LAYER_HTTP_HPP_
-#define _BLOBNET_LAYER_HTTP_HPP_
+#ifndef BLOBNET_LAYER_HTTP_HPP_
+#define BLOBNET_LAYER_HTTP_HPP_
 
 /* Includes */
 #include "../exception/HttpException.hpp"

--- a/src/input_device/JoystickInput.cpp
+++ b/src/input_device/JoystickInput.cpp
@@ -71,7 +71,7 @@ JoystickInputDevice::JoystickInputDevice(JoystickAction laction, JoystickAction 
 
 PlayerInputAbs JoystickInputDevice::transferInput()
 {
-	return PlayerInputAbs( getAction(mLeftAction), getAction(mRightAction),	getAction(mJumpAction) );
+	return { getAction(mLeftAction), getAction(mRightAction), getAction(mJumpAction) };
 }
 
 bool JoystickInputDevice::getAction(const JoystickAction& action)

--- a/src/input_device/JoystickInput.cpp
+++ b/src/input_device/JoystickInput.cpp
@@ -40,11 +40,11 @@ class JoystickInputDevice : public InputDevice
 		JoystickAction mRightAction;
 		JoystickAction mJumpAction;
 	public:
-		virtual ~JoystickInputDevice() {};
+		~JoystickInputDevice() override = default;
 		JoystickInputDevice(JoystickAction laction, JoystickAction raction,
 				JoystickAction jaction);
 
-		virtual PlayerInputAbs transferInput();
+		PlayerInputAbs transferInput() override;
 };
 
 // ********************************************************************************************************
@@ -76,7 +76,7 @@ PlayerInputAbs JoystickInputDevice::transferInput()
 
 bool JoystickInputDevice::getAction(const JoystickAction& action)
 {
-	if (action.joy != 0)
+	if (action.joy != nullptr)
 	{
 		switch (action.type)
 		{

--- a/src/input_device/JoystickPool.cpp
+++ b/src/input_device/JoystickPool.cpp
@@ -8,11 +8,11 @@
 #include <SDL2/SDL.h>
 
 // Joystick Pool
-JoystickPool* JoystickPool::mSingleton = 0; //static
+JoystickPool* JoystickPool::mSingleton = nullptr; //static
 
 JoystickPool& JoystickPool::getSingleton()
 {
-	if (mSingleton == 0)
+	if (mSingleton == nullptr)
 		mSingleton = new JoystickPool();
 
 	return *mSingleton;
@@ -51,7 +51,7 @@ void JoystickPool::probeJoysticks()
 void JoystickPool::openJoystick(const int joyIndex)
 {
 	SDL_Joystick* joystickInstance = SDL_JoystickOpen(joyIndex);
-	if (joystickInstance != NULL)
+	if (joystickInstance != nullptr)
 	{
 		mJoyMap[SDL_JoystickInstanceID(joystickInstance)] = joystickInstance;
 	}
@@ -60,7 +60,7 @@ void JoystickPool::openJoystick(const int joyIndex)
 void JoystickPool::closeJoystick(const int joyId)
 {
 	SDL_Joystick* joystickInstance = mJoyMap[joyId];
-	if (joystickInstance != NULL)
+	if (joystickInstance != nullptr)
 	{
 		SDL_JoystickClose(joystickInstance);
 	}
@@ -83,7 +83,7 @@ JoystickAction::JoystickAction(std::string string)
 {
 	type = AXIS;
 	number = 0;
-	joy = 0;
+	joy = nullptr;
 	joyid = 0;
 	try
 	{
@@ -116,9 +116,7 @@ JoystickAction::JoystickAction(const JoystickAction& action)
 	number = action.number;
 }
 
-JoystickAction::~JoystickAction()
-{
-}
+JoystickAction::~JoystickAction() = default;
 
 std::string JoystickAction::toString()
 {

--- a/src/input_device/JoystickPool.cpp
+++ b/src/input_device/JoystickPool.cpp
@@ -117,7 +117,7 @@ JoystickAction::JoystickAction(const JoystickAction& action)
 
 JoystickAction::~JoystickAction() = default;
 
-std::string JoystickAction::toString()
+std::string JoystickAction::toString() const
 {
 	const char* typestr = "unknown";
 	if (type == AXIS)
@@ -135,7 +135,7 @@ std::string JoystickAction::toString()
 	return buf.str();
 }
 
-KeyAction JoystickAction::toKeyAction()
+KeyAction JoystickAction::toKeyAction() const
 {
 	// This is an place holder
 	// Just to get simple gamepad support for the GUI

--- a/src/input_device/JoystickPool.cpp
+++ b/src/input_device/JoystickPool.cpp
@@ -69,12 +69,11 @@ void JoystickPool::closeJoystick(const int joyId)
 
 void JoystickPool::closeJoysticks()
 {
-	for (JoyMap::iterator iter = mJoyMap.begin();
-		iter != mJoyMap.end(); ++iter)
+	for (auto& iter : mJoyMap)
 	{
-		SDL_JoystickClose((*iter).second);
-		mJoyMap.erase((*iter).first);
+		SDL_JoystickClose(iter.second);
 	}
+	mJoyMap.clear();
 }
 
 // Joystick Action

--- a/src/input_device/JoystickPool.h
+++ b/src/input_device/JoystickPool.h
@@ -64,8 +64,8 @@ struct JoystickAction : public ObjectCounter<JoystickAction>
 	~JoystickAction();
 	JoystickAction(const JoystickAction& action);
 
-	std::string toString();
-	KeyAction toKeyAction();
+	std::string toString() const;
+	KeyAction toKeyAction() const;
 
 	Type type;
 

--- a/src/input_device/JoystickPool.h
+++ b/src/input_device/JoystickPool.h
@@ -57,7 +57,7 @@ struct JoystickAction : public ObjectCounter<JoystickAction>
 //		TRACKBALL
 	};
 
-	JoystickAction(std::string string);
+	explicit JoystickAction(std::string string);
 	JoystickAction(int _joyid, Type _type, int _number)
 		: type(_type), joy(nullptr), joyid(_joyid),
 			number(_number) {}

--- a/src/input_device/JoystickPool.h
+++ b/src/input_device/JoystickPool.h
@@ -59,7 +59,7 @@ struct JoystickAction : public ObjectCounter<JoystickAction>
 
 	JoystickAction(std::string string);
 	JoystickAction(int _joyid, Type _type, int _number)
-		: type(_type), joy(0), joyid(_joyid),
+		: type(_type), joy(nullptr), joyid(_joyid),
 			number(_number) {}
 	~JoystickAction();
 	JoystickAction(const JoystickAction& action);

--- a/src/input_device/KeyboardInput.cpp
+++ b/src/input_device/KeyboardInput.cpp
@@ -37,9 +37,9 @@ class KeyboardInputDevice : public InputDevice
 		SDL_Keycode mRightKey;
 		SDL_Keycode mJumpKey;
 	public:
-		virtual ~KeyboardInputDevice(){};
+		~KeyboardInputDevice() override = default;
 		KeyboardInputDevice(SDL_Keycode leftKey, SDL_Keycode rightKey, SDL_Keycode jumpKey);
-		virtual PlayerInputAbs transferInput();
+		PlayerInputAbs transferInput() override;
 };
 
 // ********************************************************************************************************
@@ -66,7 +66,7 @@ KeyboardInputDevice::KeyboardInputDevice(SDL_Keycode leftKey, SDL_Keycode rightK
 
 PlayerInputAbs KeyboardInputDevice::transferInput()
 {
-	const Uint8* keyState = SDL_GetKeyboardState(0);
+	const Uint8* keyState = SDL_GetKeyboardState(nullptr);
 
 	return PlayerInputAbs(keyState[SDL_GetScancodeFromKey(mLeftKey)], keyState[SDL_GetScancodeFromKey(mRightKey)], keyState[SDL_GetScancodeFromKey(mJumpKey)]);
 }

--- a/src/input_device/MouseInput.cpp
+++ b/src/input_device/MouseInput.cpp
@@ -44,9 +44,9 @@ class MouseInputDevice : public InputDevice
 		float mSensitivity;
 
 	public:
-		virtual ~MouseInputDevice();
+		~MouseInputDevice() override;
 		MouseInputDevice(PlayerSide player, int jumpbutton, float sensitivity);
-		virtual PlayerInputAbs transferInput();
+		PlayerInputAbs transferInput() override;
 };
 
 // ********************************************************************************************************
@@ -79,7 +79,7 @@ InputDevice* createMouseInput(PlayerSide player, int jumpbutton, float s)
 MouseInputDevice::MouseInputDevice(PlayerSide player, int jumpbutton, float sensitivity)
 	: InputDevice(), mPlayer(player), mJumpButton(jumpbutton), mMarkerX(0), mSensitivity( sensitivity )
 {
-	if (SDL_GetMouseState(NULL, NULL))
+	if (SDL_GetMouseState(nullptr, nullptr))
 		mDelay = true;
 	else
 		mDelay = false;
@@ -99,7 +99,7 @@ PlayerInputAbs MouseInputDevice::transferInput()
 	PlayerInputAbs input = PlayerInputAbs();
 
 	int deltaX;
-	int mouseState = SDL_GetRelativeMouseState(&deltaX, NULL);
+	int mouseState = SDL_GetRelativeMouseState(&deltaX, nullptr);
 
 	if (mouseState == 0)
 		mDelay = false;

--- a/src/input_device/TouchInput.cpp
+++ b/src/input_device/TouchInput.cpp
@@ -39,9 +39,9 @@ class TouchInputDevice : public InputDevice
 		int mTouchXPos;
 		int mTouchType;
 	public:
-		virtual ~TouchInputDevice(){};
+		~TouchInputDevice() override = default;
 		TouchInputDevice(PlayerSide player, int type);
-		virtual PlayerInputAbs transferInput();
+		PlayerInputAbs transferInput() override;
 };
 
 // ********************************************************************************************************
@@ -86,7 +86,7 @@ PlayerInputAbs TouchInputDevice::transferInput()
 		{
 			SDL_Finger *finger = SDL_GetTouchFinger(device, i);
 
-			if (finger == NULL)
+			if (finger == nullptr)
 				continue;
 
 			// Check the playerside
@@ -137,7 +137,7 @@ PlayerInputAbs TouchInputDevice::transferInput()
 		{
 			SDL_Finger *finger = SDL_GetTouchFinger(device, i);
 
-			if (finger == NULL)
+			if (finger == nullptr)
 				continue;
 
 			// Check the playerside

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	#endif
 #endif
 
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 	#ifndef WIN32
 		#include "config.h"
 	#endif
@@ -87,7 +87,7 @@ void setupPHYSFS()
 	const std::string separator = fs.getDirSeparator();
 	// Game should be playable out of the source package on all
 	// relevant platforms.
-	#if (defined __DESKTOP__)
+	#if BLOBBY_ON_DESKTOP
 		std::string baseSearchPath("data" + separator);
 	#elif (defined __ANDROID__)
 		std::string baseSearchPath(SDL_AndroidGetExternalStoragePath() + separator);
@@ -175,7 +175,7 @@ void setupPHYSFS()
 	#endif
 }
 
-#if __MOBILE__
+#if BLOBBY_ON_MOBILE
 	#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || (defined __SWITCH__)
 		int main(int argc, char* argv[])
 	#elif (defined __ANDROID__)

--- a/src/replays/IReplayLoader.h
+++ b/src/replays/IReplayLoader.h
@@ -55,7 +55,7 @@ class IReplayLoader : public ObjectCounter<IReplayLoader>
 		/// \brief virtual destructor
 		/// \details
 		/// \exception none
-		virtual ~IReplayLoader() {};
+		virtual ~IReplayLoader() = default;
 
 		// General Interface
 
@@ -126,7 +126,7 @@ class IReplayLoader : public ObjectCounter<IReplayLoader>
 		/// \brief protected constructor.
 		/// \details Create IReplayLoaders with createReplayLoader functions.
 		/// \exception none
-		IReplayLoader() {};
+		IReplayLoader() = default;
 
 	private:
 		/// \todo add documentation

--- a/src/replays/ReplayPlayer.cpp
+++ b/src/replays/ReplayPlayer.cpp
@@ -28,13 +28,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "DuelMatch.h"
 
 /* implementation */
-ReplayPlayer::ReplayPlayer()
-{
-}
+ReplayPlayer::ReplayPlayer() = default;
 
-ReplayPlayer::~ReplayPlayer()
-{
-}
+ReplayPlayer::~ReplayPlayer() = default;
 
 bool ReplayPlayer::endOfFile() const
 {

--- a/src/replays/ReplayRecorder.h
+++ b/src/replays/ReplayRecorder.h
@@ -47,9 +47,9 @@ class FileWrite;
 struct VersionMismatchException : public std::exception, public ObjectCounter<VersionMismatchException>
 {
 	VersionMismatchException(const std::string& filename, uint8_t major, uint8_t minor);
-	~VersionMismatchException() noexcept;
+	~VersionMismatchException() noexcept override;
 
-	virtual const char* what() const noexcept;
+	const char* what() const noexcept override;
 
 	std::string error;
 	uint8_t major;

--- a/src/replays/ReplaySavePoint.cpp
+++ b/src/replays/ReplaySavePoint.cpp
@@ -19,7 +19,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "ReplaySavePoint.h"
 
-#include <limits.h>
+#include <climits>
 
 #include "GenericIO.h"
 

--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -393,7 +393,7 @@ void DedicatedServer::createGame(std::shared_ptr<NetworkPlayer> left,
 								PlayerSide switchSide, std::string rules,
 								int scoreToWin, float gamespeed)
 {
-	auto newgame = std::make_shared<NetworkGame>(*mServer.get(), left, right,
+	auto newgame = std::make_shared<NetworkGame>(*mServer, left, right,
 								switchSide, rules, scoreToWin, gamespeed);
 	left->setGame( newgame );
 	right->setGame( newgame );

--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -256,9 +256,9 @@ void DedicatedServer::updateGames()
 	// this loop ensures that all games that have finished (eg because one
 	// player left) still process network packets, to let the other player
 	// finalize its interactions (sending replays etc).
-	for(auto it = mPlayerMap.begin(); it != mPlayerMap.end(); ++it)
+	for(auto& it : mPlayerMap)
 	{
-		auto game = it->second->getGame();
+		auto game = it.second->getGame();
 		if(game && !game->isGameValid())
 		{
 			game->processPackets();

--- a/src/server/DedicatedServer.h
+++ b/src/server/DedicatedServer.h
@@ -52,7 +52,7 @@ class DedicatedServer
 		/// simulatanious connections
 		/// \todo Maybe two classes for server info: local server info for a server, and remote for data sent to client
 		/// \param is_local: Set to true, to indicate a locally hosted server intended for a single game.
-		DedicatedServer(const ServerInfo& info, const std::vector<std::string>& rulefile,
+		DedicatedServer(ServerInfo info, const std::vector<std::string>& rulefile,
 						const std::vector<float>& speeds, int max_clients, bool is_local = false);
 		~DedicatedServer();
 
@@ -82,8 +82,8 @@ class DedicatedServer
 		void processBlobbyServerPresent( const packet_ptr& packet );
 		// creates a new game with those players
 		// does not add the game to the active game list
-		void createGame(std::shared_ptr<NetworkPlayer> left, std::shared_ptr<NetworkPlayer> right,
-						PlayerSide switchSide, std::string rules, int scoreToWin, float gamespeed);
+		void createGame(NetworkPlayer& left, NetworkPlayer& right,
+						PlayerSide switchSide, const std::string& rules, int scoreToWin, float gamespeed);
 		// broadcasts the current server  status to all waiting clients
 
 		// member variables

--- a/src/server/MatchMaker.cpp
+++ b/src/server/MatchMaker.cpp
@@ -258,7 +258,7 @@ void MatchMaker::startGame(PlayerID host, PlayerID client)
 			switchSide = LEFT_PLAYER;
 	}
 
-	mCreateGame( leftPlayer->second, rightPlayer->second, switchSide,
+	mCreateGame( *leftPlayer->second, *rightPlayer->second, switchSide,
 				mPossibleGameRules.at(game->second.rules).file,
 				game->second.points,
 				mPossibleGameSpeeds.at(game->second.speed) );

--- a/src/server/MatchMaker.cpp
+++ b/src/server/MatchMaker.cpp
@@ -68,7 +68,7 @@ unsigned MatchMaker::addGame( OpenGame game )
 	while(mOpenGames.find(mIDCounter) != mOpenGames.end())
 	{
 		++mIDCounter;
-	};
+	}
 
 	mOpenGames[mIDCounter] = game;
 

--- a/src/server/MatchMaker.h
+++ b/src/server/MatchMaker.h
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "raknet/NetworkTypes.h"
 #include <map>
+#include <utility>
 #include <vector>
 #include <functional>
 #include "Global.h"
@@ -45,10 +46,10 @@ public:
 	// set callback functions
 	typedef std::function<void(std::shared_ptr<NetworkPlayer>, std::shared_ptr<NetworkPlayer>,
 								PlayerSide, std::string rules, int score, float speed)> create_game_fn;
-	void setCreateGame( create_game_fn func) { mCreateGame = func;};
+	void setCreateGame( create_game_fn func) { mCreateGame = std::move(func);};
 
 	typedef std::function<void(const RakNet::BitStream& stream, PlayerID target)> send_fn;
-	void setSendFunction( send_fn func ) { mSendPacket = func; };
+	void setSendFunction( send_fn func ) { mSendPacket = std::move(func); };
 
 	// communication
 	void receiveLobbyPacket( PlayerID sender, RakNet::BitStream& content );

--- a/src/server/MatchMaker.h
+++ b/src/server/MatchMaker.h
@@ -44,8 +44,8 @@ public:
 	void removePlayer( PlayerID id );
 
 	// set callback functions
-	typedef std::function<void(std::shared_ptr<NetworkPlayer>, std::shared_ptr<NetworkPlayer>,
-								PlayerSide, std::string rules, int score, float speed)> create_game_fn;
+	typedef std::function<void(NetworkPlayer&, NetworkPlayer&,
+								PlayerSide, const std::string& rules, int score, float speed)> create_game_fn;
 	void setCreateGame( create_game_fn func) { mCreateGame = std::move(func);};
 
 	typedef std::function<void(const RakNet::BitStream& stream, PlayerID target)> send_fn;

--- a/src/server/NetworkGame.cpp
+++ b/src/server/NetworkGame.cpp
@@ -46,8 +46,8 @@ extern int SWLS_GameSteps;
 
 /* implementation */
 
-NetworkGame::NetworkGame(RakServer& server, std::shared_ptr<NetworkPlayer> leftPlayer,
-			std::shared_ptr<NetworkPlayer> rightPlayer, PlayerSide switchedSide,
+NetworkGame::NetworkGame(RakServer& server, NetworkPlayer& leftPlayer,
+			NetworkPlayer& rightPlayer, PlayerSide switchedSide,
 			std::string rules, int scoreToWin, float speed) :
 	mServer(server),
 	mMatch(new DuelMatch(false, rules, scoreToWin)),
@@ -60,25 +60,25 @@ NetworkGame::NetworkGame(RakServer& server, std::shared_ptr<NetworkPlayer> leftP
 	mGameValid(true)
 {
 	// check that both players don't have an active game
-	if(leftPlayer->getGame())
+	if(leftPlayer.getGame())
 	{
 		BOOST_THROW_EXCEPTION( std::runtime_error("Trying to start a game with player already in another game!") );
 	}
 
-	if(rightPlayer->getGame())
+	if(rightPlayer.getGame())
 	{
 		BOOST_THROW_EXCEPTION( std::runtime_error("Trying to start a game with player already in another game!") );
 	}
 
-	mMatch->setPlayers( leftPlayer->getIdentity(), rightPlayer->getIdentity() );
+	mMatch->setPlayers( leftPlayer.getIdentity(), rightPlayer.getIdentity() );
 	mMatch->setInputSources(mLeftInput, mRightInput);
 
-	mLeftPlayer = leftPlayer->getID();
-	mRightPlayer = rightPlayer->getID();
+	mLeftPlayer = leftPlayer.getID();
+	mRightPlayer = rightPlayer.getID();
 	mSwitchedSide = switchedSide;
 
-	mRecorder->setPlayerNames(leftPlayer->getName(), rightPlayer->getName());
-	mRecorder->setPlayerColors(leftPlayer->getColor(), rightPlayer->getColor());
+	mRecorder->setPlayerNames(leftPlayer.getName(), rightPlayer.getName());
+	mRecorder->setPlayerColors(leftPlayer.getColor(), rightPlayer.getColor());
 	mRecorder->setGameSpeed(mSpeedController.getGameSpeed());
 	mRecorder->setGameRules(rules);
 

--- a/src/server/NetworkGame.h
+++ b/src/server/NetworkGame.h
@@ -51,8 +51,8 @@ class NetworkGame : public ObjectCounter<NetworkGame>
 		// decides which player is switched.
 		/// \exception Throws FileLoadException, if the desired rules file could not be loaded
 		///	\exception Throws std::runtime_error, if \p leftPlayer or \p rightPlayer are already assigned to a game.
-		NetworkGame(RakServer& server, std::shared_ptr<NetworkPlayer> leftPlayer,
-					std::shared_ptr<NetworkPlayer> rightPlayer, PlayerSide switchedSide,
+		NetworkGame(RakServer& server, NetworkPlayer& leftPlayer,
+					NetworkPlayer& rightPlayer, PlayerSide switchedSide,
 					std::string rules, int scoreToWin, float speed);
 
 		~NetworkGame();

--- a/src/server/NetworkPlayer.cpp
+++ b/src/server/NetworkPlayer.cpp
@@ -55,7 +55,7 @@ NetworkPlayer::NetworkPlayer(PlayerID id, RakNet::BitStream& stream) : mID(id)
 	int color;
 	stream.Read(color);
 
-	mIdentity = PlayerIdentity(charName, color, false, (PlayerSide)playerSide);
+	mIdentity = PlayerIdentity(charName, (Color)color, false, (PlayerSide)playerSide);
 }
 
 bool NetworkPlayer::valid() const

--- a/src/server/NetworkPlayer.cpp
+++ b/src/server/NetworkPlayer.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "NetworkPlayer.h"
 
 /* includes */
+#include <utility>
 
 /* implementation */
 
@@ -94,5 +95,5 @@ const std::shared_ptr<NetworkGame>& NetworkPlayer::getGame() const
 
 void NetworkPlayer::setGame(std::shared_ptr<NetworkGame> game)
 {
-	mGame = game;
+	mGame = std::move(game);
 }

--- a/src/server/servermain.cpp
+++ b/src/server/servermain.cpp
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <ctime>
 #include <future>
 
-#include <errno.h>
+#include <cerrno>
 #include <unistd.h>
 
 #include <boost/algorithm/string/split.hpp>
@@ -166,15 +166,15 @@ int main(int argc, char** argv)
 			g_run_server = false;
 			break;
 		}
-		 else if ( cmd_vec[0] == "players" )
+		else if ( cmd_vec[0] == "players" )
 		{
 			server.printAllPlayers(std::cout);
 		}
-		 else if ( cmd_vec[0] == "games" )
+		else if ( cmd_vec[0] == "games" )
 		{
 			server.printAllGames(std::cout);
 		}
-		 else if ( cmd_vec[0] == "status" )
+		else if ( cmd_vec[0] == "status" )
 		{
 			std::cout << "Blobby Server Status Report " << (SWLS_RunningTime / UPDATE_FREQUENCY / 60 / 60) << "h running \n";
 			std::cout << " packet count: " << SWLS_PacketCount << "\n";

--- a/src/server/servermain.cpp
+++ b/src/server/servermain.cpp
@@ -50,7 +50,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <cstdarg>
 #endif
 
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 #ifndef WIN32
 #include "config.h"
 #endif
@@ -305,7 +305,7 @@ void setup_physfs(char* argv0)
 {
 	FileSystem& fs = FileSystem::getSingleton();
 
-	#if __DESKTOP__
+	#if BLOBBY_ON_DESKTOP
 	#ifndef WIN32
 		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby");
 		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/rules.zip");

--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -34,7 +34,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* implementation */
 
 
-GameState::GameState(DuelMatch* match) : mMatch(match), mSaveReplay(false), mErrorMessage("")
+GameState::GameState(DuelMatch* match) : mMatch(match), mSaveReplay(false)
 {
 }
 

--- a/src/state/LobbyStates.cpp
+++ b/src/state/LobbyStates.cpp
@@ -37,9 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "GenericIO.h"
 #include "GameLogic.h"
 
-LobbySubstate::~LobbySubstate()
-{
-}
+LobbySubstate::~LobbySubstate() = default;
 
 
 LobbyState::LobbyState(ServerInfo info, PreviousState previous) :

--- a/src/state/LocalGameState.cpp
+++ b/src/state/LocalGameState.cpp
@@ -41,8 +41,8 @@ LocalGameState::LocalGameState()
 	PlayerIdentity leftPlayer = config->loadPlayerIdentity(LEFT_PLAYER, false);
 	PlayerIdentity rightPlayer = config->loadPlayerIdentity(RIGHT_PLAYER, false);
 
-	std::shared_ptr<InputSource> leftInput = InputSourceFactory::createInputSource( config, LEFT_PLAYER);
-	std::shared_ptr<InputSource> rightInput = InputSourceFactory::createInputSource( config, RIGHT_PLAYER);
+	std::shared_ptr<InputSource> leftInput = InputSourceFactory::createInputSource( *config, LEFT_PLAYER);
+	std::shared_ptr<InputSource> rightInput = InputSourceFactory::createInputSource( *config, RIGHT_PLAYER);
 
 	// create default replay name
 	setDefaultReplayName(leftPlayer.getName(), rightPlayer.getName());

--- a/src/state/NetworkSearchState.cpp
+++ b/src/state/NetworkSearchState.cpp
@@ -68,13 +68,12 @@ NetworkSearchState::NetworkSearchState() :
 NetworkSearchState::~NetworkSearchState()
 {
 	// Disconnect from servers
-	for (ClientList::iterator iter = mQueryClients.begin();
-		iter != mQueryClients.end(); ++iter)
+	for (auto& client : mQueryClients)
 	{
-		if (*iter)
+		if (client)
 		{
-			(*iter)->Disconnect(50);
-			delete *iter;
+			client->Disconnect(50);
+			delete client;
 		}
 	}
 	// request ping thread to stop
@@ -96,7 +95,7 @@ void NetworkSearchState::step_impl()
 	// set to true to initiate server connection
 	bool doEnterServer = false;
 
-	for (ClientList::iterator iter = mQueryClients.begin();
+	for (auto iter = mQueryClients.begin();
 		iter != mQueryClients.end(); ++iter)
 	{
 		bool skip = false;
@@ -255,9 +254,9 @@ void NetworkSearchState::step_impl()
 	}
 
 	std::vector<std::string> servernames;
-	for (unsigned int i = 0; i < mScannedServers.size(); i++)
+	for (auto& server : mScannedServers)
 	{
-		servernames.push_back(std::string(mScannedServers[i].name) + " (" + std::to_string(mScannedServers[i].waitingplayers) + ")" );
+		servernames.push_back(std::string(server.name) + " (" + std::to_string(server.waitingplayers) + ")" );
 	}
 
 	if( imgui.doSelectbox(GEN_ID, Vector2(25.0, 60.0), Vector2(775.0, 470.0), servernames, mSelectedServer) == SBA_DBL_CLICK )

--- a/src/state/NetworkSearchState.cpp
+++ b/src/state/NetworkSearchState.cpp
@@ -357,7 +357,7 @@ void NetworkSearchState::step_impl()
 			PlayerSide localSide = (PlayerSide)config.getInteger("network_side");
 
 			PlayerIdentity local_player = config.loadPlayerIdentity(localSide, true);
-			ServerInfo info( local_player.getName().c_str());
+			ServerInfo info(local_player.getName());
 			std::vector<std::string> rule_vec{config.getString("rules")};
 
 
@@ -396,7 +396,7 @@ void NetworkSearchState::step_impl()
 		config.loadFile("config.xml");
 
 		PlayerIdentity local_player = config.loadPlayerIdentity((PlayerSide)config.getInteger("network_side"), true);
-		mHostedServer.reset(new ServerInfo( local_player.getName().c_str()));
+		mHostedServer.reset(new ServerInfo( local_player.getName()));
 		std::strncpy(mHostedServer->hostname,
 					mPingClient->PlayerIDToDottedIP(mPingClient->GetInternalID()),
 					sizeof(mHostedServer->hostname));

--- a/src/state/NetworkSearchState.cpp
+++ b/src/state/NetworkSearchState.cpp
@@ -143,14 +143,14 @@ void NetworkSearchState::step_impl()
 								doEnterServer = true;
 							}
 						}
-						 else
+						else
 						{
 							std::cout << "duplicate server entry\n";
 							std::cout << info << "\n";
 						}
 
 					}
-					 else
+					else
 					{
 						std::cout << " server invalid " << packet->length << " " << ServerInfo::BLOBBY_SERVER_PRESENT_PACKET_SIZE << "\n";
 					}

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -223,7 +223,7 @@ void NetworkGameState::step_impl()
 				// read colors
 				int temp;
 				stream.Read(temp);
-				Color ncolor = temp;
+				auto ncolor = Color(temp);
 
 				mRemotePlayer->setName(charName);
 

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <iostream>
 
 #include <boost/scoped_array.hpp>
+#include <utility>
 
 #include "raknet/RakClient.h"
 #include "raknet/PacketEnumerations.h"
@@ -52,11 +53,10 @@ NetworkGameState::NetworkGameState( std::shared_ptr<RakClient> client, int rule_
 	: GameState(new DuelMatch(true, DEFAULT_RULES_FILE, score_to_win))
 	, mNetworkState(WAITING_FOR_OPPONENT)
 	, mWaitingForReplay(false)
-	, mClient(client)
+	, mClient(std::move(client))
 	, mWinningPlayer(NO_PLAYER)
 	, mSelectedChatmessage(0)
 	, mChatCursorPosition(0)
-	, mChattext("")
 {
 	std::shared_ptr<IUserConfigReader> config = IUserConfigReader::createUserConfigReader("config.xml");
 	mOwnSide = (PlayerSide)config->getInteger("network_side");

--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -46,7 +46,7 @@ OptionState::OptionState()
 	mScriptNames = FileSystem::getSingleton().enumerateFiles("scripts", ".lua");
 
 	// hack. we cant use something like push_front, though
-	mScriptNames.push_back("Human");
+	mScriptNames.emplace_back("Human");
 	std::swap(mScriptNames[0], mScriptNames[mScriptNames.size() - 1]);
 
 	for(unsigned int i = 0; i < mScriptNames.size(); ++i)
@@ -587,7 +587,7 @@ void InputOptionsState::handleKeyboardInput(int base_x, std::string& lastActionK
 	if (mSetKeyboard == base_x + 1)
 		mSetKeyboard = base_x + 2;
 
-	if (mSetKeyboard == base_x + 2 && input[IA_LEFT] != "")
+	if (mSetKeyboard == base_x + 2 && !input[IA_LEFT].empty())
 		mSetKeyboard = base_x + 3;
 
 	imgui.doText(GEN_ID, Vector2(base_x + 34.0, 190.0), TextManager::OP_RIGHT_KEY);
@@ -601,7 +601,7 @@ void InputOptionsState::handleKeyboardInput(int base_x, std::string& lastActionK
 	if (mSetKeyboard == base_x + 3)
 		mSetKeyboard = base_x + 4;
 
-	if (mSetKeyboard == base_x + 4 && input[IA_RIGHT] != "")
+	if (mSetKeyboard == base_x + 4 && !input[IA_RIGHT].empty())
 		mSetKeyboard = base_x + 5;
 
 	imgui.doText(GEN_ID, Vector2(base_x + 34.0, 260.0), TextManager::OP_JUMP_KEY );
@@ -615,7 +615,7 @@ void InputOptionsState::handleKeyboardInput(int base_x, std::string& lastActionK
 	if (mSetKeyboard == base_x + 5)
 		mSetKeyboard = base_x + 6;
 
-	if (mSetKeyboard == base_x + 6 && input[IA_JUMP] != "")
+	if (mSetKeyboard == base_x + 6 && !input[IA_JUMP].empty())
 		mSetKeyboard = 0;
 }
 
@@ -693,7 +693,7 @@ void InputOptionsState::getKeyboardInput(std::string& action, TextManager::STRIN
 		return;
 
 	getInputPrompt(TextManager::OP_PRESS_KEY_FOR, input);
-	action = lastActionKey;
+	action = std::move(lastActionKey);
 	if (InputManager::getSingleton()->exit())
 		action = mOldString;
 }

--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -185,7 +185,7 @@ GraphicOptionsState::~GraphicOptionsState() = default;
 
 void GraphicOptionsState::save()
 {
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 	if ((mOptionConfig.getBool("fullscreen") != mFullscreen) ||	(mOptionConfig.getString("device") != mRenderer))
 	{
 		mOptionConfig.setBool("fullscreen", mFullscreen);
@@ -220,7 +220,7 @@ void GraphicOptionsState::step_impl()
 	imgui.doImage(GEN_ID, Vector2(400.0, 300.0), "background");
 	imgui.doOverlay(GEN_ID, Vector2(0.0, 0.0), Vector2(800.0, 600.0));
 
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 	imgui.doText(GEN_ID, Vector2(34.0, 10.0), TextManager::OP_VIDEO);
 
 	if (imgui.doButton(GEN_ID, Vector2(34.0, 40.0), TextManager::OP_FULLSCREEN))
@@ -245,7 +245,7 @@ void GraphicOptionsState::step_impl()
 #endif
 	float heightOfElement = 110.0;
 
-#if __MOBILE__
+#if BLOBBY_ON_MOBILE
 	heightOfElement = 10.0;
 #endif
 
@@ -260,7 +260,7 @@ void GraphicOptionsState::step_impl()
 	else
 		imgui.doImage(GEN_ID, Vector2(204.0, heightOfElement + 13.0), "gfx/pfeil_rechts.bmp");
 
-#if __MOBILE__
+#if BLOBBY_ON_MOBILE
 	float standardLineHeight = 50.0;
 #else
 	float standardLineHeight = 30.0;
@@ -456,7 +456,7 @@ void InputOptionsState::save()
 	mOptionConfig.saveFile("inputconfig.xml");
 }
 
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 void InputOptionsState::step_impl()
 {
 	IMGUI& imgui = IMGUI::getSingleton();
@@ -1004,7 +1004,7 @@ void MiscOptionsState::step_impl()
 		imgui.doImage(GEN_ID, Vector2(513.0, 92.0), "gfx/pfeil_rechts.bmp");
 	}
 
-#if __DESKTOP__
+#if BLOBBY_ON_DESKTOP
 	if (imgui.doButton(GEN_ID, Vector2(484.0, 120.0), TextManager::OP_FPS))
 	{
 		mShowFPS = !mShowFPS;

--- a/src/state/ReplayState.cpp
+++ b/src/state/ReplayState.cpp
@@ -162,7 +162,7 @@ void ReplayState::step_impl()
 
 			if (InputManager::getSingleton()->click())
 			{
-				float pos = (mousepos.x - prog_pos.x) / 700.0;
+				float pos = (mousepos.x - prog_pos.x) / 700.f;
 				mPositionJump = pos * mReplayPlayer->getReplayLength();
 			}
 		}


### PR DESCRIPTION
Fixes complaints of clang-tidy. There are still enough left, though :)
I've separated this into individual commits that group together changes of the same kind.
Most changes are really simple, in that they only affect a single code line locally.
But some, (esp. eb14cdfb8474c0173fceaf0c820e572075853178) make changes that have dependencies across files.

I think I've also fixed a bug where an `#ifdef` should really have been an `#if`. 

There are some places where a `std::move` could be used, but is currently not helpful due to `JoystickAction` not having a move constructor. `JoystickAction` copy c'tor currently makes things nontrivial, because it gets a joystick pointer from a global singleton. Is this really necessary, can we not just copy the pointer?