### PR TITLE
De-singletonify

### DIFF
--- a/src/Blood.cpp
+++ b/src/Blood.cpp
@@ -25,12 +25,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <cstdlib>
 
 #include "RenderManager.h"
-#include "IUserConfigReader.h"
 
 /* implementation */
-
-
-BloodManager* BloodManager::mSingleton = nullptr;
 
 // Blood class
 // ------------
@@ -43,13 +39,13 @@ Blood::Blood(const Vector2& position, const Vector2& direction, int player):
 {
 }
 
-void Blood::step()
+void Blood::step(RenderManager& renderer)
 {
 	const float GRAVITY = 3;
 	/// \todo this is the only place where we do step-rate independent calculations.
 	///			is this intended behaviour???
 	int diff = SDL_GetTicks() - mLastFrame;
-	RenderManager::getSingleton().drawParticle(mPos, mPlayer);
+	renderer.drawParticle(mPos, mPlayer);
 	const int SPEED = 45;
 	
 	//this calculation is NOT based on physical rules
@@ -63,19 +59,18 @@ void Blood::step()
 // -------------------
 
 
-BloodManager::BloodManager()
+BloodManager::BloodManager(bool enabled) : mEnabled(enabled)
 {
-	mEnabled =  IUserConfigReader::createUserConfigReader("config.xml")->getBool("blood");
 }
 
-void BloodManager::step()
+void BloodManager::step(RenderManager& renderer)
 {
 	// don't do any processing if there are no particles
 	if ( !mEnabled || mParticles.empty() )
 		return;
 	
 	// start drawing
-	RenderManager::getSingleton().startDrawParticles();
+	renderer.startDrawParticles();
 	
 	// iterate over all particles
 	auto it = mParticles.begin();
@@ -83,14 +78,14 @@ void BloodManager::step()
 	{
 		auto it2 = it;
 		++it;	
-		it2->step();
+		it2->step(renderer);
 		// delete particles below lower screen border
 		if (it2->getPosition().y > 600)
 			mParticles.erase(it2);
 	}
 	
 	// finish drawing
-	RenderManager::getSingleton().endDrawParticles();
+	renderer.endDrawParticles();
 }
 
 void BloodManager::spillBlood(Vector2 pos, float intensity, int player)

--- a/src/Blood.h
+++ b/src/Blood.h
@@ -26,6 +26,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 //Bleeding blobs can be a lot of fun :)
 
+class RenderManager;
+
 /*!	\class Blood
 	\brief Container to hold the data of a single drop of blood
 */
@@ -40,7 +42,7 @@ class Blood
 		
 		/// this function has to be called each step
 		/// it updates position and velocity.
-		void step();
+		void step(RenderManager& renderer);
 		
 		/// gets the current position of this drop
 		const Vector2& getPosition() const { return mPos; }
@@ -60,8 +62,10 @@ class Blood
 class BloodManager : private boost::noncopyable
 {
 	public:
+		explicit BloodManager(bool enabled);
+
 		/// update function, to be called each step.
-		void step();
+		void step(RenderManager& renderer);
 		
 		/// \brief creates a blood effect
 		/// \param pos Position the effect occurs
@@ -71,21 +75,8 @@ class BloodManager : private boost::noncopyable
 		
 		/// enables or disables blood effects
 		void enable(bool enable) { mEnabled = enable; }
-		
-		/// gets the instance of BloodManager, creating one if it does not exists
-		static BloodManager& getSingleton()
-		{
-			if (!mSingleton)
-				mSingleton = new BloodManager;
-			
-			return *mSingleton;
-		}
-		
+
 	private:
-		/// default constructor, sets mEnabled to the value
-		///	set in config.xml
-		BloodManager();
-		
 		/// helper function which returns an integer between 
 		/// min and max, boundaries included
 		static int random(int min, int max);
@@ -95,7 +86,4 @@ class BloodManager : private boost::noncopyable
 		
 		/// true, if blood should be handled/drawn
 		bool mEnabled;
-		
-		/// singleton
-		static BloodManager* mSingleton;
 };

--- a/src/Blood.h
+++ b/src/Blood.h
@@ -21,8 +21,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #pragma once
 
 #include "Vector.h"
-#include <list>
-#include <boost/noncopyable.hpp>
+#include <vector>
+#include <random>
 
 //Bleeding blobs can be a lot of fun :)
 
@@ -57,9 +57,9 @@ class Blood
 /*!	\class BloodManager
 	\brief Manages blood effects
 	\details this class is responsible for managing blood effects, creating and deleting the particles, 
-			updating their positions etc. It is designed as a singleton, so it is noncopyable.
+			updating their positions etc.
 */
-class BloodManager : private boost::noncopyable
+class BloodManager
 {
 	public:
 		explicit BloodManager(bool enabled);
@@ -79,11 +79,14 @@ class BloodManager : private boost::noncopyable
 	private:
 		/// helper function which returns an integer between 
 		/// min and max, boundaries included
-		static int random(int min, int max);
+		int random(int min, int max);
 		
 		/// list which contains all currently existing blood particles
-		std::list<Blood> mParticles;
+		std::vector<Blood> mParticles;
 		
 		/// true, if blood should be handled/drawn
 		bool mEnabled;
+
+		/// Random number generator
+		std::mt19937 mRng;
 };

--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -257,7 +257,7 @@ void IMGUI::doText(int id, const Vector2& position, const std::string& text, uns
 
 void IMGUI::doText(int id, const Vector2& position, TextManager::STRING text, unsigned int flags)
 {
-	doText(id, position, TextManager::getSingleton()->getString(text), flags);
+	doText(id, position, getText(text), flags);
 }
 
 void IMGUI::doOverlay(int id, const Vector2& pos1, const Vector2& pos2, const Color& col, float alpha)
@@ -275,7 +275,7 @@ void IMGUI::doOverlay(int id, const Vector2& pos1, const Vector2& pos2, const Co
 
 bool IMGUI::doButton(int id, const Vector2& position, TextManager::STRING text, unsigned int flags)
 {
-	return doButton(id, position, TextManager::getSingleton()->getString(text), flags);
+	return doButton(id, position, getText(text), flags);
 }
 
 bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, unsigned int flags)
@@ -356,9 +356,9 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 		// React to back button
 		if (mLastKeyAction == BACK)
 		{
-			if ((text == (TextManager::getSingleton())->getString(TextManager::LBL_CANCEL)) ||
-			    (text == (TextManager::getSingleton())->getString(TextManager::LBL_NO)) ||
-			    (text == (TextManager::getSingleton())->getString(TextManager::MNU_LABEL_EXIT)))
+			if ((text == getText(TextManager::LBL_CANCEL)) ||
+			    (text == getText(TextManager::LBL_NO)) ||
+			    (text == getText(TextManager::MNU_LABEL_EXIT)))
 			{
 				//todo: Workaround to catch backkey
 				clicked = true;
@@ -1108,4 +1108,16 @@ void IMGUI::doCursor(bool draw)
 bool IMGUI::usingCursor() const
 {
 	return mUsingCursor;
+}
+
+const TextManager& IMGUI::textMgr() const {
+	return *mTextManager;
+}
+
+const std::string& IMGUI::getText(TextManager::STRING id) const {
+	return textMgr().getString(id);
+}
+
+void IMGUI::setTextMgr(std::string lang) {
+	mTextManager.reset(new TextManager(std::move(lang)));
 }

--- a/src/IMGUI.h
+++ b/src/IMGUI.h
@@ -81,6 +81,10 @@ class IMGUI : public ObjectCounter<IMGUI>
 		void doInactiveMode(bool inactive) { mInactive = inactive; }
 
 		int getNextId() { return mIdCounter++; };
+
+		const TextManager& textMgr() const;
+		const std::string& getText(TextManager::STRING id) const;
+		void setTextMgr(std::string lang);
 	private:
 		IMGUI();
 		~IMGUI();
@@ -97,5 +101,7 @@ class IMGUI : public ObjectCounter<IMGUI>
 		bool mUsingCursor;
 
 		int mIdCounter;
+
+		std::unique_ptr<TextManager> mTextManager;
 };
 

--- a/src/InputDevice.h
+++ b/src/InputDevice.h
@@ -37,8 +37,9 @@ class InputDevice : public ObjectCounter<InputDevice>
 };
 
 struct JoystickAction;
+class InputManager;
 
 InputDevice* createKeyboardInput(SDL_Keycode left, SDL_Keycode right, SDL_Keycode jump);
 InputDevice* createJoystrickInput(JoystickAction left, JoystickAction right, JoystickAction jump);
 InputDevice* createTouchInput(PlayerSide side, int type);
-InputDevice* createMouseInput(PlayerSide player, int jumpbutton, float sensitivity);
+InputDevice* createMouseInput(InputManager* inputMgr, PlayerSide player, int jumpbutton, float sensitivity);

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -59,7 +59,7 @@ InputManager::~InputManager()
 	JoystickPool::getSingleton().closeJoysticks();
 }
 
-InputDevice* InputManager::beginGame(PlayerSide side) const
+InputDevice* InputManager::beginGame(PlayerSide side)
 {
 	SDL_Window* window = RenderManager::getSingleton().getWindow();
 
@@ -84,7 +84,7 @@ InputDevice* InputManager::beginGame(PlayerSide side) const
 	{
 		int jumpbutton = config.getInteger(prefix + "mouse_jumpbutton");
 		float sensitivity = config.getFloat(prefix + "mouse_sensitivity");
-		return createMouseInput(side, jumpbutton, sensitivity);
+		return createMouseInput(this, side, jumpbutton, sensitivity);
 	}
 	// load config for keyboard
 

--- a/src/InputManager.h
+++ b/src/InputManager.h
@@ -47,7 +47,7 @@ class InputManager : public ObjectCounter<InputManager>
 		static InputManager* getSingleton();
 		~InputManager();
 
-		InputDevice* beginGame(PlayerSide side) const;
+		InputDevice* beginGame(PlayerSide side);
 
 		bool running() const;
 		void setEndBlobby();	// call to trigger the event that ends blobby, i.e. running will return false after this call.

--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -23,13 +23,19 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* includes */
 #include "FileRead.h"
+#include "Blood.h"
+#include "IUserConfigReader.h"
 
 /* implementation */
 #define INVALID_FONT_INDEX -1
 
 RenderManager* RenderManager::mSingleton = nullptr;
 
-RenderManager::RenderManager() : mDrawGame(false)
+RenderManager::~RenderManager() = default;
+
+RenderManager::RenderManager() :
+	mDrawGame(false),
+	mBloodMgr(new BloodManager(IUserConfigReader::createUserConfigReader("config.xml")->getBool("blood")))
 {
 	//assert(!mSingleton);
 	if (mSingleton)
@@ -41,6 +47,10 @@ RenderManager::RenderManager() : mDrawGame(false)
 	mSingleton = this;
 	mMouseMarkerPosition = -100.0;
 	mNeedRedraw = true;
+}
+
+BloodManager& RenderManager::getBlood() {
+	return *mBloodMgr;
 }
 
 SDL_Surface* RenderManager::highlightSurface(SDL_Surface* surface, int luminance)

--- a/src/RenderManager.h
+++ b/src/RenderManager.h
@@ -28,6 +28,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "BlobbyDebug.h"
 
 
+class BloodManager;
+
 // Text definitions
 static const int FONT_WIDTH_NORMAL 	=	24;	// Height and width of the normal font.
 static const int LINE_SPACER_NORMAL	=	 6;	// Extra space between 2 lines in a normal SelectBox.
@@ -101,7 +103,7 @@ struct BufferedImage : public ObjectCounter<BufferedImage>
 class RenderManager : public ObjectCounter<RenderManager>
 {
 	public:
-		virtual ~RenderManager() = default;
+		virtual ~RenderManager();
 
 		static RenderManager* createRenderManagerSDL();
 		//static RenderManager* createRenderManagerGP2X();
@@ -114,6 +116,7 @@ class RenderManager : public ObjectCounter<RenderManager>
 		}
 
 		Color getOscillationColor() const;
+		BloodManager& getBlood();
 
 		// Draws the stuff
 		virtual void draw() = 0;
@@ -211,6 +214,7 @@ class RenderManager : public ObjectCounter<RenderManager>
 		bool mNeedRedraw;
 
 	private:
+		std::unique_ptr<BloodManager> mBloodMgr;
 		static RenderManager *mSingleton;
 
 };

--- a/src/TextManager.cpp
+++ b/src/TextManager.cpp
@@ -31,19 +31,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "FileRead.h"
 
 /* implementation */
-TextManager* TextManager::mSingleton = nullptr;
 
+TextManager::TextManager(std::string l): lang(std::move(l)) {
+	mStrings.resize(COUNT);
+	setDefault();
 
-TextManager* TextManager::createTextManager(const std::string& langname){
-	delete mSingleton;
-
-	mSingleton = new TextManager(langname);
-
-	std::string langfile = "lang_"+langname+".xml";
+	std::string langfile = "lang_"+lang+".xml";
 
 	bool loaded = false;
 	try{
-		loaded = mSingleton->loadFromXML(langfile);
+		loaded = loadFromXML(langfile);
 	} catch(FileLoadException& fle) {
 		std::cerr << fle.what() << std::endl;
 	}
@@ -52,31 +49,12 @@ TextManager* TextManager::createTextManager(const std::string& langname){
 		std::cerr << "error loading language " << langfile << "!" << std::endl;
 		std::cerr << "\tfalling back to english" << std::endl;
 	}
-
-	return mSingleton;
-}
-
-const TextManager* TextManager::getSingleton(){
-	return mSingleton;
-}
-
-TextManager::TextManager(std::string l): lang(std::move(l)) {
-	mStrings.resize(COUNT);
-	setDefault();
-}
-
-void TextManager::switchLanguage(const std::string& langname){
-	// if old and new language are the same, nothing must be done
-	if(langname == mSingleton->lang)
-		return;
-
-	// otherwise, the old TextManager is destroyed and a new one is created
-	createTextManager(langname);
 }
 
 const std::string& TextManager::getString(STRING str) const{
 	return mStrings[str];
 }
+
 std::string TextManager::getLang() const{
 	return lang;
 }

--- a/src/TextManager.h
+++ b/src/TextManager.h
@@ -168,6 +168,8 @@ class TextManager
 			COUNT
 		};
 
+		explicit TextManager(std::string language);
+
 		/// returns the string identified by str
 		const std::string& getString(STRING str) const;
 
@@ -176,24 +178,10 @@ class TextManager
 		/// returns count of utf-8 characters
 		static const int getUTF8Length(const std::string& str);
 
-		/// returns the mSingleton
-		static const TextManager* getSingleton();
-
-		/// creates a textmanager for a particular language
-		static TextManager* createTextManager(const std::string& langname);
-
-		/// switches the language
-		static void switchLanguage(const std::string& langname);
-
 		/// map to map abbreviations to full name (e.g. de to deutsch)
 		static std::map<std::string, std::string> language_names;
 
 	private:
-		/// private construktor, use createTextManager
-		explicit TextManager(std::string l);
-
-		/// Singleton
-		static TextManager* mSingleton;
 
 		/// vector with all strings
 		std::vector<std::string> mStrings;

--- a/src/input_device/MouseInput.cpp
+++ b/src/input_device/MouseInput.cpp
@@ -36,17 +36,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 class MouseInputDevice : public InputDevice
 {
+	public:
+		~MouseInputDevice() override;
+		MouseInputDevice(InputManager* inputMgr, PlayerSide player, int jumpbutton, float sensitivity);
+		PlayerInputAbs transferInput() override;
+
 	private:
 		PlayerSide mPlayer;
 		int mJumpButton;
 		int mMarkerX;
 		bool mDelay; // The pressed button of the mainmenu must be ignored
 		float mSensitivity;
-
-	public:
-		~MouseInputDevice() override;
-		MouseInputDevice(PlayerSide player, int jumpbutton, float sensitivity);
-		PlayerInputAbs transferInput() override;
+		InputManager* mInputManager;
 };
 
 // ********************************************************************************************************
@@ -57,7 +58,7 @@ class MouseInputDevice : public InputDevice
 //		Creator Function
 // -------------------------------------------------------------------------------------------------
 
-InputDevice* createMouseInput(PlayerSide player, int jumpbutton, float s)
+InputDevice* createMouseInput(InputManager* inputMgr, PlayerSide player, int jumpbutton, float s)
 {
 	float maxFactor = 3;
 	// mapping  [0:1]  -> [-1:1] 	: se = (s - 0.5) * 2
@@ -70,28 +71,29 @@ InputDevice* createMouseInput(PlayerSide player, int jumpbutton, float s)
 	float se = (s - 0.5) * 2;
 	float sensitivity = std::exp(std::log(maxFactor) * se);
 
-	return new MouseInputDevice(player, jumpbutton, sensitivity);
+	return new MouseInputDevice(inputMgr, player, jumpbutton, sensitivity);
 }
 
 // -------------------------------------------------------------------------------------------------
 // 		Keyboard Input Device
 // -------------------------------------------------------------------------------------------------
-MouseInputDevice::MouseInputDevice(PlayerSide player, int jumpbutton, float sensitivity)
-	: InputDevice(), mPlayer(player), mJumpButton(jumpbutton), mMarkerX(0), mSensitivity( sensitivity )
+MouseInputDevice::MouseInputDevice(InputManager* inputMgr, PlayerSide player, int jumpbutton, float sensitivity)
+	: InputDevice(), mPlayer(player), mJumpButton(jumpbutton), mMarkerX(0), mSensitivity( sensitivity ),
+	mInputManager(inputMgr)
 {
 	if (SDL_GetMouseState(nullptr, nullptr))
 		mDelay = true;
 	else
 		mDelay = false;
 
-	assert(InputManager::getSingleton()->isMouseCaptured() == false);
-	InputManager::getSingleton()->captureMouse( true );
+	assert(mInputManager->isMouseCaptured() == false);
+	mInputManager->captureMouse( true );
 }
 
 MouseInputDevice::~MouseInputDevice()
 {
-	assert(InputManager::getSingleton()->isMouseCaptured() == true);
-	InputManager::getSingleton()->captureMouse( false );
+	assert(mInputManager->isMouseCaptured() == true);
+	mInputManager->captureMouse( false );
 }
 
 PlayerInputAbs MouseInputDevice::transferInput()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,7 +240,7 @@ void setupPHYSFS()
 		UserConfig gameConfig;
 		gameConfig.loadFile("config.xml");
 
-		TextManager::createTextManager(gameConfig.getString("language"));
+		IMGUI::getSingleton().setTextMgr(gameConfig.getString("language"));
 
 		if(gameConfig.getString("device") == "SDL")
 			rmanager = RenderManager::createRenderManagerSDL();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,7 +332,7 @@ void setupPHYSFS()
 			{
 				rmanager->draw();
 				IMGUI::getSingleton().end();
-				BloodManager::getSingleton().step();
+				rmanager->getBlood().step(*rmanager);
 				rmanager->refresh();
 			}
 			scontroller.update();

--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -83,7 +83,7 @@ void GameState::presentGame()
 			smanager.playSound("sounds/bums.wav", e.intensity + BALL_HIT_PLAYER_SOUND_VOLUME);
 			/// \todo save that position inside the event
 			Vector2 hitPos = mMatch->getBallPosition() + (mMatch->getBlobPosition(e.side) - mMatch->getBallPosition()).normalise().scale(31.5);
-			BloodManager::getSingleton().spillBlood(hitPos, e.intensity, e.side);
+			RenderManager::getSingleton().getBlood().spillBlood(hitPos, e.intensity, e.side);
 		}
 
 		if( e.event == MatchEvent::PLAYER_ERROR )

--- a/src/state/LobbyStates.cpp
+++ b/src/state/LobbyStates.cpp
@@ -289,7 +289,7 @@ void LobbyMainSubstate::step(const ServerStatusData& status)
 
 	// player list
 	std::vector<std::string> gamelist;
-	gamelist.push_back( TextManager::getSingleton()->getString(TextManager::NET_OPEN_GAME) );
+	gamelist.push_back( imgui.getText(TextManager::NET_OPEN_GAME) );
 	for ( const auto& game : status.mOpenGames)
 	{
 		gamelist.push_back( game.name + (game.hasPassword ? "🔒" : "") );
@@ -319,15 +319,15 @@ void LobbyMainSubstate::step(const ServerStatusData& status)
 
 		// info panel contents:
 		//  * gamespeed
-		imgui.doText(GEN_ID, Vector2(435, 100), TextManager::getSingleton()->getString(TextManager::NET_SPEED) +
+		imgui.doText(GEN_ID, Vector2(435, 100), imgui.getText(TextManager::NET_SPEED) +
 					 std::to_string(int(0.5 + 100.0 / 75.0 * status.mPossibleSpeeds.at(status.getGame(gameIndex).speed))) + "%");
 		//  * points
-		imgui.doText(GEN_ID, Vector2(435, 135), TextManager::getSingleton()->getString(TextManager::NET_POINTS) +
+		imgui.doText(GEN_ID, Vector2(435, 135), imgui.getText(TextManager::NET_POINTS) +
 											 std::to_string(status.getGame(gameIndex).score) );
 
 		//  * rulesfile
-		imgui.doText(GEN_ID, Vector2(435, 170), TextManager::getSingleton()->getString(TextManager::NET_RULES_TITLE) );
-		std::string rulesstring = status.mPossibleRules.at(status.getGame(gameIndex).rules) + TextManager::getSingleton()->getString(TextManager::NET_RULES_BY);
+		imgui.doText(GEN_ID, Vector2(435, 170), imgui.getText(TextManager::NET_RULES_TITLE) );
+		std::string rulesstring = status.mPossibleRules.at(status.getGame(gameIndex).rules) + imgui.getText(TextManager::NET_RULES_BY);
 		rulesstring += status.mPossibleRulesAuthor.at(mChosenRules);
 		for (unsigned int i = 0; i < rulesstring.length(); i += 25)
 		{
@@ -353,7 +353,7 @@ void LobbyMainSubstate::step(const ServerStatusData& status)
 
 
 		// open game button
-		if( imgui.doButton(GEN_ID, Vector2(435, 430), TextManager::getSingleton()->getString(TextManager::NET_JOIN) ) ||
+		if( imgui.doButton(GEN_ID, Vector2(435, 430), imgui.getText(TextManager::NET_JOIN) ) ||
 			doEnterGame)
 		{
 			// send open game packet to server
@@ -376,24 +376,24 @@ void LobbyMainSubstate::step(const ServerStatusData& status)
 
 		// info panel contents:
 		//  * gamespeed
-		if(imgui.doButton(GEN_ID, Vector2(435, 100), TextManager::getSingleton()->getString(TextManager::NET_SPEED) +
+		if(imgui.doButton(GEN_ID, Vector2(435, 100), imgui.getText(TextManager::NET_SPEED) +
 					 std::to_string(int(0.5 + 100.0 / 75.0 * status.mPossibleSpeeds.at(mChosenSpeed))) + "%"))
 		{
 			mChosenSpeed = (mChosenSpeed + 1) % status.mPossibleSpeeds.size();
 		}
 		//  * points
-		if(imgui.doButton(GEN_ID, Vector2(435, 135), TextManager::getSingleton()->getString(TextManager::NET_POINTS) +
+		if(imgui.doButton(GEN_ID, Vector2(435, 135), imgui.getText(TextManager::NET_POINTS) +
 											 std::to_string( mPossibleScores.at(mChosenScore) ) ))
 		{
 			mChosenScore = (mChosenScore + 1) % mPossibleScores.size();
 		}
 
 		//  * rulesfile
-		if(imgui.doButton(GEN_ID, Vector2(435, 170), TextManager::getSingleton()->getString(TextManager::NET_RULES_TITLE) ))
+		if(imgui.doButton(GEN_ID, Vector2(435, 170), imgui.getText(TextManager::NET_RULES_TITLE) ))
 		{
 			mChosenRules = (mChosenRules + 1) % status.mPossibleRules.size();
 		}
-		std::string rulesstring = status.mPossibleRules.at(mChosenRules) + TextManager::getSingleton()->getString(TextManager::NET_RULES_BY);
+		std::string rulesstring = status.mPossibleRules.at(mChosenRules) + imgui.getText(TextManager::NET_RULES_BY);
 		rulesstring += status.mPossibleRulesAuthor.at(mChosenRules);
 		for (unsigned int i = 0; i < rulesstring.length(); i += 25)
 		{
@@ -415,7 +415,7 @@ void LobbyMainSubstate::step(const ServerStatusData& status)
 		}
 
 		// open game button
-		if( imgui.doButton(GEN_ID, Vector2(435, 430), TextManager::getSingleton()->getString(TextManager::NET_OPEN_GAME) ))
+		if( imgui.doButton(GEN_ID, Vector2(435, 430), imgui.getText(TextManager::NET_OPEN_GAME) ))
 		{
 			// send open game packet to server
 			RakNet::BitStream stream;
@@ -474,14 +474,14 @@ void LobbyGameSubstate::step( const ServerStatusData& status )
 
 	// info panel contents:
 	//  * gamespeed
-	imgui.doText(GEN_ID, Vector2(435, 100), TextManager::getSingleton()->getString(TextManager::NET_SPEED) +
+	imgui.doText(GEN_ID, Vector2(435, 100), imgui.getText(TextManager::NET_SPEED) +
 				 std::to_string(int(0.5 + 100.0 / 75.0 * status.mPossibleSpeeds.at(mSpeed))) + "%");
 	//  * points
-	imgui.doText(GEN_ID, Vector2(435, 135), TextManager::getSingleton()->getString(TextManager::NET_POINTS) +
+	imgui.doText(GEN_ID, Vector2(435, 135), imgui.getText(TextManager::NET_POINTS) +
 										 std::to_string( mScore ) );
 	//  * rulesfile
-	imgui.doText(GEN_ID, Vector2(435, 170), TextManager::getSingleton()->getString(TextManager::NET_RULES_TITLE) );
-	std::string rulesstring = status.mPossibleRules.at(mRules) + TextManager::getSingleton()->getString(TextManager::NET_RULES_BY);
+	imgui.doText(GEN_ID, Vector2(435, 170), imgui.getText(TextManager::NET_RULES_TITLE) );
+	std::string rulesstring = status.mPossibleRules.at(mRules) + imgui.getText(TextManager::NET_RULES_BY);
 	rulesstring += status.mPossibleRulesAuthor.at(mRules);
 	for (unsigned int i = 0; i < rulesstring.length(); i += 25)
 	{
@@ -491,7 +491,7 @@ void LobbyGameSubstate::step( const ServerStatusData& status )
 	// open game button
 	if( mIsHost )
 	{
-		if( imgui.doButton(GEN_ID, Vector2(435, 395), TextManager::getSingleton()->getString(TextManager::NET_LEAVE) ) )
+		if( imgui.doButton(GEN_ID, Vector2(435, 395), imgui.getText(TextManager::NET_LEAVE) ) )
 		{
 			RakNet::BitStream stream;
 			stream.Write((unsigned char)ID_LOBBY);
@@ -499,7 +499,7 @@ void LobbyGameSubstate::step( const ServerStatusData& status )
 			mClient->Send(&stream, LOW_PRIORITY, RELIABLE_ORDERED, 0);
 		}
 
-		if( !no_players && (imgui.doButton(GEN_ID, Vector2(435, 430), TextManager::getSingleton()->getString(TextManager::MNU_LABEL_START) ) || doEnterGame) )
+		if( !no_players && (imgui.doButton(GEN_ID, Vector2(435, 430), imgui.getText(TextManager::MNU_LABEL_START) ) || doEnterGame) )
 		{
 			// Start Game
 			RakNet::BitStream stream;
@@ -512,12 +512,12 @@ void LobbyGameSubstate::step( const ServerStatusData& status )
 
 		if( no_players )
 		{
-			imgui.doText(GEN_ID, Vector2(435, 430), TextManager::getSingleton()->getString(TextManager::GAME_WAITING));
+			imgui.doText(GEN_ID, Vector2(435, 430), imgui.getText(TextManager::GAME_WAITING));
 		}
 	}
 	else
 	{
-		if( imgui.doButton(GEN_ID, Vector2(435, 430), TextManager::getSingleton()->getString(TextManager::NET_LEAVE) ) )
+		if( imgui.doButton(GEN_ID, Vector2(435, 430), imgui.getText(TextManager::NET_LEAVE) ) )
 		{
 			RakNet::BitStream stream;
 			stream.Write((unsigned char)ID_LOBBY);

--- a/src/state/NetworkSearchState.cpp
+++ b/src/state/NetworkSearchState.cpp
@@ -322,11 +322,11 @@ void NetworkSearchState::step_impl()
 		imgui.doText(GEN_ID, Vector2(50, 130), mScannedServers[mSelectedServer].hostname);
 
 		std::stringstream activegames;
-		activegames << TextManager::getSingleton()->getString(TextManager::NET_ACTIVE_GAMES)
+		activegames << imgui.getText(TextManager::NET_ACTIVE_GAMES)
 					<< mScannedServers[mSelectedServer].activegames;
 		imgui.doText(GEN_ID, Vector2(50, 160), activegames.str());
 		std::stringstream waitingplayer;
-		waitingplayer << TextManager::getSingleton()->getString(TextManager::NET_WAITING_PLAYER)
+		waitingplayer << imgui.getText(TextManager::NET_WAITING_PLAYER)
 					  << mScannedServers[mSelectedServer].waitingplayers;
 		imgui.doText(GEN_ID, Vector2(50, 190), waitingplayer.str());
 		std::string description = mScannedServers[mSelectedServer].description;

--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -964,7 +964,7 @@ void MiscOptionsState::save()
 	SoundManager::getSingleton().setVolume(mOptionConfig.getFloat("global_volume"));
 	SoundManager::getSingleton().setMute(mOptionConfig.getBool("mute"));
 	RenderManager::getSingleton().setBackground(std::string("backgrounds/") + mOptionConfig.getString("background"));
-	TextManager::switchLanguage(mOptionConfig.getString("language"));
+	IMGUI::getSingleton().setTextMgr(mOptionConfig.getString("language"));
 }
 
 void MiscOptionsState::step_impl()
@@ -1059,15 +1059,14 @@ void MiscOptionsState::step_impl()
 	imgui.doText(GEN_ID, Vector2(660.0, 330.0), FPSInPercent.str());
 
 	//! \todo this must be reworked
-	auto olang = TextManager::language_names.find(TextManager::getSingleton()->getLang());
+	auto olang = TextManager::language_names.find(imgui.textMgr().getLang());
 	if(++olang == TextManager::language_names.end()){
 		olang = TextManager::language_names.begin();
 	}
 	if (imgui.doButton(GEN_ID, Vector2(300.0, 490.0), (*olang).second)){
 		//! \todo autogenerierte liste mit allen lang_ dateien, namen auslesen
 		mLanguage = (*olang).first;
-		TextManager::switchLanguage(mLanguage);
-
+		imgui.setTextMgr(mLanguage);
 	}
 
 	if (imgui.doButton(GEN_ID, Vector2(224.0, 530.0), TextManager::LBL_OK))

--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -960,7 +960,7 @@ void MiscOptionsState::save()
 	mOptionConfig.saveFile("config.xml");
 
 	SpeedController::getMainInstance()->setDrawFPS(mOptionConfig.getBool("showfps"));
-	BloodManager::getSingleton().enable(mOptionConfig.getBool("blood"));
+	RenderManager::getSingleton().getBlood().enable(mOptionConfig.getBool("blood"));
 	SoundManager::getSingleton().setVolume(mOptionConfig.getFloat("global_volume"));
 	SoundManager::getSingleton().setMute(mOptionConfig.getBool("mute"));
 	RenderManager::getSingleton().setBackground(std::string("backgrounds/") + mOptionConfig.getString("background"));
@@ -1018,8 +1018,8 @@ void MiscOptionsState::step_impl()
 	if (imgui.doButton(GEN_ID, Vector2(484.0, 160.0), TextManager::OP_BLOOD))
 	{
 		mShowBlood = !mShowBlood;
-		BloodManager::getSingleton().enable(mShowBlood);
-		BloodManager::getSingleton().spillBlood(Vector2(484.0, 160.0), 1.5, 2);
+		RenderManager::getSingleton().getBlood().enable(mShowBlood);
+		RenderManager::getSingleton().getBlood().spillBlood(Vector2(484.0, 160.0), 1.5, 2);
 	}
 	if (mShowBlood)
 	{


### PR DESCRIPTION
Some more cleanup, though this time a bit more involved.
I've removed the singletons for `TextManager` and `BloodManager` by giving `IMGUI` and  `RenderManager` owning pointers to these objects, respectively. Do you agree with this?

I've also used to opportunity to slightly clean up the particle code.

For the `InputManager` singleton, that still exists, but I've slightly reduced its usage by `MouseInput` now taking a non-owning pointer to it.