### PR TITLE
CMake 3.3 build workflow

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -1,0 +1,40 @@
+# The purpose of this workflow is to verify that we are compatible with older versions of CMake than available through
+# the ubuntu package sources
+name: Old CMake
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  workflow_dispatch:
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    env:
+      CMAKE_VERSION: 3.3.0
+    steps:
+      - name: Setup Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            libsdl2-dev \
+            libphysfs-dev \
+            libboost-dev
+      - uses: actions/checkout@v2
+      - name: Get CMake
+        # note: newer versions of cmake have changed the naming scheme to use lower-case 'linux',
+        # which will break this script
+        run: |
+          wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+          tar -xf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+          mv cmake-${CMAKE_VERSION}-Linux-x86_64 old-cmake
+      - name: Configure CMake and Build
+        run: |
+          echo "Using CMake"
+          old-cmake/bin/cmake --version
+          echo "Configuring"
+          old-cmake/bin/cmake .
+          echo "Building"
+          old-cmake/bin/cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.3)
 
 include(CPack)
 


### PR DESCRIPTION
change the minimum required CMake version to 3.3 and add a workflow that verifies compatibility

This establishes that, in fact, our cmake files are not compatible with 3.1 as the old `CMakeLists.txt` claimed, but require at least 3.3. The change we require appears to be

> The [cmake(1)](https://cmake.org/cmake/help/v3.3/manual/cmake.1.html#manual:cmake(1)) -E tar command learned a new --format<format> option to specify the archive format to be written.
Now the declared and actual requirements are in sync, and we automatically verify this from now on.

I do hope to modernize the cmake files at some point (i.e. using "modern" cmake based on targets and their dependencies, instead of variables), and even if that increases the minimum required cmake version, I think this automatic test will come in handy.