### PR TITLE
fix crash when plugin/out a joystick while playing

### DIFF
--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -71,7 +71,7 @@ IMGUI::IMGUI()
 	mQueue = new RenderQueue;
 	mActiveButton = -1;
 	mHeldWidget = 0;
-	mLastKeyAction = NONE;
+	mLastKeyAction = KeyAction::NONE;
 	mLastWidget = 0;
 	mButtonReset = false;
 	mInactive = false;
@@ -99,25 +99,25 @@ void IMGUI::begin()
 		mQueue->pop();
 
 
-	mLastKeyAction = NONE;
+	mLastKeyAction = KeyAction::NONE;
 
 	if (InputManager::getSingleton()->up())
-		mLastKeyAction = UP;
+		mLastKeyAction = KeyAction::UP;
 
 	if (InputManager::getSingleton()->down())
-		mLastKeyAction = DOWN;
+		mLastKeyAction = KeyAction::DOWN;
 
 	if (InputManager::getSingleton()->left())
-		mLastKeyAction = LEFT;
+		mLastKeyAction = KeyAction::LEFT;
 
 	if (InputManager::getSingleton()->right())
-		mLastKeyAction = RIGHT;
+		mLastKeyAction = KeyAction::RIGHT;
 
 	if (InputManager::getSingleton()->select())
-		mLastKeyAction = SELECT;
+		mLastKeyAction = KeyAction::SELECT;
 
 	if (InputManager::getSingleton()->exit())
-		mLastKeyAction = BACK;
+		mLastKeyAction = KeyAction::BACK;
 
 	mIdCounter = 0;
 }
@@ -306,14 +306,14 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 		{
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -331,19 +331,19 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 			obj.flags = obj.flags | TF_HIGHLIGHT;
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case SELECT:
+				case KeyAction::SELECT:
 					clicked = true;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 				default:
 					break;
@@ -351,7 +351,7 @@ bool IMGUI::doButton(int id, const Vector2& position, const std::string& text, u
 		}
 
 		// React to back button
-		if (mLastKeyAction == BACK)
+		if (mLastKeyAction == KeyAction::BACK)
 		{
 			if ((text == getText(TextManager::LBL_CANCEL)) ||
 			    (text == getText(TextManager::LBL_NO)) ||
@@ -436,14 +436,14 @@ bool IMGUI::doScrollbar(int id, const Vector2& position, float& value)
 		{
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -461,24 +461,24 @@ bool IMGUI::doScrollbar(int id, const Vector2& position, float& value)
 			obj.type = ACTIVESCROLLBAR;
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case LEFT:
+				case KeyAction::LEFT:
 					value -= 0.1;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case RIGHT:
+				case KeyAction::RIGHT:
 					value += 0.1;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -588,14 +588,14 @@ bool IMGUI::doEditbox(int id, const Vector2& position, unsigned int length, std:
 		{
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -620,26 +620,26 @@ bool IMGUI::doEditbox(int id, const Vector2& position, unsigned int length, std:
 			obj.type = ACTIVEEDITBOX;
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case LEFT:
+				case KeyAction::LEFT:
 					if (cpos > 0)
 						cpos--;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case RIGHT:
+				case KeyAction::RIGHT:
 					if (cpos < text.length())
 						cpos++;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -797,14 +797,14 @@ SelectBoxAction IMGUI::doSelectbox(int id, const Vector2& pos1, const Vector2& p
 		{
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -822,32 +822,32 @@ SelectBoxAction IMGUI::doSelectbox(int id, const Vector2& pos1, const Vector2& p
 			obj.type = ACTIVESELECTBOX;
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case LEFT:
+				case KeyAction::LEFT:
 					if (selected > 0)
 					{
 						selected--;
 						changed = SBA_SELECT;
 					}
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case RIGHT:
+				case KeyAction::RIGHT:
 					if (selected + 1 < entries.size())
 					{
 						selected++;
 						changed = SBA_SELECT;
 					}
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -952,14 +952,14 @@ void IMGUI::doChatbox(int id, const Vector2& pos1, const Vector2& pos2, const st
 		{
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:
@@ -977,30 +977,30 @@ void IMGUI::doChatbox(int id, const Vector2& pos1, const Vector2& pos2, const st
 			obj.type = ACTIVECHAT;
 			switch (mLastKeyAction)
 			{
-				case DOWN:
+				case KeyAction::DOWN:
 					mActiveButton = 0;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case UP:
+				case KeyAction::UP:
 					mActiveButton = mLastWidget;
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case LEFT:
+				case KeyAction::LEFT:
 					if (selected > 0)
 					{
 						selected--;
 					}
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
-				case RIGHT:
+				case KeyAction::RIGHT:
 					if (selected + 1 < entries.size())
 					{
 						selected++;
 					}
-					mLastKeyAction = NONE;
+					mLastKeyAction = KeyAction::NONE;
 					break;
 
 				default:

--- a/src/InputDevice.h
+++ b/src/InputDevice.h
@@ -40,6 +40,6 @@ struct JoystickAction;
 class InputManager;
 
 std::unique_ptr<InputDevice> createKeyboardInput(SDL_Keycode left, SDL_Keycode right, SDL_Keycode jump);
-std::unique_ptr<InputDevice> createJoystrickInput(JoystickAction left, JoystickAction right, JoystickAction jump);
+std::unique_ptr<InputDevice> createJoystickInput(InputManager* inputMgr, JoystickAction left, JoystickAction right, JoystickAction jump);
 std::unique_ptr<InputDevice> createTouchInput(PlayerSide side, int type);
 std::unique_ptr<InputDevice> createMouseInput(InputManager* inputMgr, PlayerSide player, int jumpbutton, float sensitivity);

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -30,7 +30,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "UserConfig.h"
 #include "RenderManager.h"
 #include "InputDevice.h"
-#include "input_device/JoystickPool.h"
 
 /* implementation */
 
@@ -40,9 +39,12 @@ const unsigned int DOUBLE_CLICK_TIME = 200;
 
 InputManager::InputManager()
 {
+	// joystick
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 	SDL_JoystickEventState(SDL_ENABLE);
-	JoystickPool::getSingleton().probeJoysticks();
+	mJoystickPool = std::unique_ptr<JoystickPool>{new JoystickPool()};
+	mJoystickPool->probeJoysticks();
+
 	assert (mSingleton == nullptr);
 	mSingleton = this;
 	mRunning = true;
@@ -56,7 +58,6 @@ InputManager::InputManager()
 
 InputManager::~InputManager()
 {
-	JoystickPool::getSingleton().closeJoysticks();
 }
 
 std::unique_ptr<InputDevice> InputManager::beginGame(PlayerSide side)
@@ -101,7 +102,7 @@ std::unique_ptr<InputDevice> InputManager::beginGame(PlayerSide side)
 		JoystickAction laction(config.getString(prefix + "joystick_left"));
 		JoystickAction raction(config.getString(prefix + "joystick_right"));
 		JoystickAction jaction(config.getString(prefix + "joystick_jump"));
-		return createJoystrickInput(laction, raction, jaction);
+		return createJoystickInput(this, laction, raction, jaction);
 	}
 	// load config for touch
 	else if (device == "touch")
@@ -157,10 +158,10 @@ void InputManager::updateInput()
 				mRunning = false;
 				break;
 			case SDL_JOYDEVICEADDED:
-				JoystickPool::getSingleton().openJoystick(event.jdevice.which);
+				mJoystickPool->openJoystick(event.jdevice.which);
 				break;
 			case SDL_JOYDEVICEREMOVED:
-				JoystickPool::getSingleton().closeJoystick(event.jdevice.which);
+				mJoystickPool->closeJoystick(event.jdevice.which);
 				break;
 			case SDL_KEYDOWN:
 				mLastActionKey = event.key.keysym.sym;
@@ -472,3 +473,7 @@ bool InputManager::isMouseCaptured() const
 	return mMouseCaptured;
 }
 
+JoystickPool& InputManager::getJoystickPool()
+{
+	return *mJoystickPool;
+}

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "UserConfig.h"
 #include "RenderManager.h"
 #include "InputDevice.h"
+#include "input_device/JoystickPool.h"
 
 /* implementation */
 
@@ -473,7 +474,7 @@ bool InputManager::isMouseCaptured() const
 	return mMouseCaptured;
 }
 
-JoystickPool& InputManager::getJoystickPool()
+SDL_Joystick* InputManager::getJoystickById(int joyId)
 {
-	return *mJoystickPool;
+	return mJoystickPool->getJoystick(joyId);
 }

--- a/src/InputManager.h
+++ b/src/InputManager.h
@@ -20,13 +20,17 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #pragma once
 
+#include <memory>
+
 #include <SDL2/SDL.h>
 
 #include "PlayerInput.h"
 #include "Vector.h"
 #include "BlobbyDebug.h"
 
-enum KeyAction
+#include "input_device/JoystickPool.h"
+
+enum class KeyAction
 {
 	UP,
 	DOWN,
@@ -36,6 +40,7 @@ enum KeyAction
 	BACK,
 	NONE
 };
+
 
 class InputDevice;
 
@@ -79,6 +84,8 @@ class InputManager : public ObjectCounter<InputManager>
 
 		bool windowFocus() const;
 
+		JoystickPool& getJoystickPool();
+
 		// config conversion methods
 		//std::string keyToString(const SDL_keysym& key) const;
 
@@ -116,6 +123,8 @@ class InputManager : public ObjectCounter<InputManager>
 		bool mRunning;
 
 		bool mMouseCaptured;
+
+		std::unique_ptr<JoystickPool> mJoystickPool;
 
 		InputManager();
 

--- a/src/InputManager.h
+++ b/src/InputManager.h
@@ -28,8 +28,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Vector.h"
 #include "BlobbyDebug.h"
 
-#include "input_device/JoystickPool.h"
-
 enum class KeyAction
 {
 	UP,
@@ -41,7 +39,7 @@ enum class KeyAction
 	NONE
 };
 
-
+class JoystickPool;
 class InputDevice;
 
 /// \brief class for managing input
@@ -84,7 +82,7 @@ class InputManager : public ObjectCounter<InputManager>
 
 		bool windowFocus() const;
 
-		JoystickPool& getJoystickPool();
+		SDL_Joystick* getJoystickById(int joyId);
 
 		// config conversion methods
 		//std::string keyToString(const SDL_keysym& key) const;

--- a/src/input_device/JoystickInput.cpp
+++ b/src/input_device/JoystickInput.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* other includes */
 #include "JoystickPool.h"
+#include "InputManager.h"
 
 // ********************************************************************************************************
 // 		Interface Definition
@@ -39,9 +40,11 @@ class JoystickInputDevice : public InputDevice
 		JoystickAction mLeftAction;
 		JoystickAction mRightAction;
 		JoystickAction mJumpAction;
+		
+		InputManager* mInputManager;
 	public:
 		~JoystickInputDevice() override = default;
-		JoystickInputDevice(JoystickAction laction, JoystickAction raction,
+		JoystickInputDevice(InputManager* inputMgr, JoystickAction laction, JoystickAction raction,
 				JoystickAction jaction);
 
 		PlayerInputAbs transferInput() override;
@@ -55,17 +58,20 @@ class JoystickInputDevice : public InputDevice
 //		Creator Function
 // -------------------------------------------------------------------------------------------------
 
-std::unique_ptr<InputDevice> createJoystrickInput(JoystickAction left, JoystickAction right, JoystickAction jump)
+std::unique_ptr<InputDevice> createJoystickInput(InputManager* inputMgr, JoystickAction left, JoystickAction right, JoystickAction jump)
 {
-	return std::unique_ptr<InputDevice>{new JoystickInputDevice(left, right, jump)};
+	return std::unique_ptr<InputDevice>{new JoystickInputDevice(inputMgr, left, right, jump)};
 }
 
 // -------------------------------------------------------------------------------------------------
 // 		Joystick Input Device
 // -------------------------------------------------------------------------------------------------
 
-JoystickInputDevice::JoystickInputDevice(JoystickAction laction, JoystickAction raction, JoystickAction jaction)
-	: mLeftAction(laction), mRightAction(raction), mJumpAction(jaction)
+JoystickInputDevice::JoystickInputDevice(InputManager* inputMgr, JoystickAction laction, JoystickAction raction, JoystickAction jaction)
+	: mLeftAction(laction)
+	, mRightAction(raction)
+	, mJumpAction(jaction)
+	, mInputManager(inputMgr)
 {
 }
 
@@ -76,27 +82,28 @@ PlayerInputAbs JoystickInputDevice::transferInput()
 
 bool JoystickInputDevice::getAction(const JoystickAction& action)
 {
-	if (action.joy != nullptr)
+	SDL_Joystick* joystick = mInputManager->getJoystickPool().getJoystick(action.joyid);
+	if (joystick != nullptr)
 	{
 		switch (action.type)
 		{
 			case JoystickAction::AXIS:
 				if (action.number < 0)
 				{
-					if (SDL_JoystickGetAxis(action.joy,
+					if (SDL_JoystickGetAxis(joystick,
 						-action.number - 1) < -15000)
 						return true;
 				}
 				else if (action.number > 0)
 				{
-					if (SDL_JoystickGetAxis(action.joy,
+					if (SDL_JoystickGetAxis(joystick,
 						action.number - 1) > 15000)
 						return true;
 				}
 				break;
 
 			case JoystickAction::BUTTON:
-				if (SDL_JoystickGetButton(action.joy,
+				if (SDL_JoystickGetButton(joystick,
 							action.number))
 					return true;
 				break;

--- a/src/input_device/JoystickInput.cpp
+++ b/src/input_device/JoystickInput.cpp
@@ -82,7 +82,7 @@ PlayerInputAbs JoystickInputDevice::transferInput()
 
 bool JoystickInputDevice::getAction(const JoystickAction& action)
 {
-	SDL_Joystick* joystick = mInputManager->getJoystickPool().getJoystick(action.joyid);
+	SDL_Joystick* joystick = mInputManager->getJoystickById(action.joyid);
 	if (joystick != nullptr)
 	{
 		switch (action.type)

--- a/src/input_device/JoystickPool.cpp
+++ b/src/input_device/JoystickPool.cpp
@@ -7,22 +7,24 @@
 
 #include <SDL2/SDL.h>
 
+#include <InputManager.h>
+
 // Joystick Pool
-JoystickPool* JoystickPool::mSingleton = nullptr; //static
-
-JoystickPool& JoystickPool::getSingleton()
+JoystickPool::~JoystickPool()
 {
-	if (mSingleton == nullptr)
-		mSingleton = new JoystickPool();
-
-	return *mSingleton;
+	for (auto& iter : mJoyMap)
+	{
+		SDL_JoystickClose(iter.second);
+	}
+	mJoyMap.clear();
 }
+
 
 SDL_Joystick* JoystickPool::getJoystick(int id)
 {
 	SDL_Joystick* joy =  mJoyMap[id];
 
-	if (!joy)
+	if (joy == nullptr)
 	{
 		std::cerr << "Warning: could not find joystick number " << id << "!" << std::endl;
 		mJoyMap.erase(id);
@@ -67,22 +69,12 @@ void JoystickPool::closeJoystick(const int joyId)
 	mJoyMap.erase(joyId);
 }
 
-void JoystickPool::closeJoysticks()
-{
-	for (auto& iter : mJoyMap)
-	{
-		SDL_JoystickClose(iter.second);
-	}
-	mJoyMap.clear();
-}
-
 // Joystick Action
 
 JoystickAction::JoystickAction(std::string string)
 {
 	type = AXIS;
 	number = 0;
-	joy = nullptr;
 	joyid = 0;
 	try
 	{
@@ -98,21 +90,11 @@ JoystickAction::JoystickAction(std::string string)
 			if (sscanf(str, "joy_%d_axis_%d", &joyid, &number) < 2)
 				throw string;
 		}
-
-		joy = JoystickPool::getSingleton().getJoystick(joyid);
 	}
 	catch (const std::string& e)
 	{
 		std::cerr << "Parse error in joystick config: " << e << std::endl;
 	}
-}
-
-JoystickAction::JoystickAction(const JoystickAction& action)
-{
-	type = action.type;
-	joy = JoystickPool::getSingleton().getJoystick(action.joyid);
-	joyid = action.joyid;
-	number = action.number;
 }
 
 JoystickAction::~JoystickAction() = default;

--- a/src/input_device/JoystickPool.cpp
+++ b/src/input_device/JoystickPool.cpp
@@ -16,7 +16,6 @@ JoystickPool::~JoystickPool()
 	{
 		SDL_JoystickClose(iter.second);
 	}
-	mJoyMap.clear();
 }
 
 

--- a/src/input_device/JoystickPool.h
+++ b/src/input_device/JoystickPool.h
@@ -21,28 +21,28 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #pragma once
 
 #include <map>
+#include <string>
 
 #include <SDL2/SDL_events.h>
 
 #include "BlobbyDebug.h"
-#include "InputManager.h"
+
+enum class KeyAction;
 
 class JoystickPool : public ObjectCounter<JoystickPool>
 {
 	public:
-		static JoystickPool& getSingleton();
-
+		JoystickPool() = default;
+		~JoystickPool();
 		SDL_Joystick* getJoystick(int id);
 
 		void openJoystick(const int joyId);
 		void closeJoystick(const int joyId);
 		void probeJoysticks();
-		void closeJoysticks();
 
 	private:
 		typedef std::map<int, SDL_Joystick*> JoyMap;
 		JoyMap mJoyMap;
-		static JoystickPool* mSingleton;
 };
 
 struct JoystickAction : public ObjectCounter<JoystickAction>
@@ -59,17 +59,16 @@ struct JoystickAction : public ObjectCounter<JoystickAction>
 
 	explicit JoystickAction(std::string string);
 	JoystickAction(int _joyid, Type _type, int _number)
-		: type(_type), joy(nullptr), joyid(_joyid),
-			number(_number) {}
+		: type(_type)
+		, joyid(_joyid)
+		, number(_number) {}
 	~JoystickAction();
-	JoystickAction(const JoystickAction& action);
+	JoystickAction(const JoystickAction& action) = default;
 
 	std::string toString() const;
 	KeyAction toKeyAction() const;
 
 	Type type;
-
-	SDL_Joystick* joy;
 	int joyid;
 
 	// Note: Axis are stored as the SDL axis +1, so we can use


### PR DESCRIPTION
This PR fixes a crash when using gamepads and joysticks.

Precondition:
1. joystick plugged in
2. joystick configured in settings
3. game is running

Problem:
Game crashes when you plug-out and plug-in the configured gamepad/joystick.

Reason:
The source of the crash was that we were storing an SDL_Joystick pointer, which would be invalid after plug-out/plug-in, whereas now we are only storing the ID so the nullptr check will catch a missing joystick.

Other minor improvements were made for the fix.