### PR TITLE
get rid of boost::noncopyable

### DIFF
--- a/src/File.h
+++ b/src/File.h
@@ -23,7 +23,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <string>
 #include <cinttypes>
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_array.hpp>
 
 
@@ -47,7 +46,7 @@ struct PHYSFS_File;
 							message physfs created.
 	\todo 	write tests for this class.
 */
-class File : boost::noncopyable, public ObjectCounter<File>
+class File : public ObjectCounter<File>
 {
 	public:
 		/// \brief closes the file
@@ -60,6 +59,10 @@ class File : boost::noncopyable, public ObjectCounter<File>
 		/// \sa close()
 		/// \throw nothing
 		~File();
+
+        // no copies
+        File(const File&) = delete;
+        File& operator=(const File&) = delete;
 		
 		// ------------------------------------
 		// information querying interface

--- a/src/File.h
+++ b/src/File.h
@@ -60,9 +60,9 @@ class File : public ObjectCounter<File>
 		/// \throw nothing
 		~File();
 
-        // no copies
-        File(const File&) = delete;
-        File& operator=(const File&) = delete;
+		// no copies
+		File(const File&) = delete;
+		File& operator=(const File&) = delete;
 		
 		// ------------------------------------
 		// information querying interface

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -22,18 +22,20 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <vector>
-#include <boost/noncopyable.hpp>
 
 #include "FileExceptions.h"
 #include "BlobbyDebug.h"
 
 // some convenience wrappers around physfs
 
-class FileSystem : public boost::noncopyable, public ObjectCounter<FileSystem>
+class FileSystem : public ObjectCounter<FileSystem>
 {
 	public:
 		explicit FileSystem(const std::string& path);
 		~FileSystem();
+
+        FileSystem(const FileSystem&) = delete;
+        FileSystem& operator=(const FileSystem&) = delete;
 
 		/// \brief gets the file system
 		/// \details throws an error when file system has

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -34,8 +34,8 @@ class FileSystem : public ObjectCounter<FileSystem>
 		explicit FileSystem(const std::string& path);
 		~FileSystem();
 
-        FileSystem(const FileSystem&) = delete;
-        FileSystem& operator=(const FileSystem&) = delete;
+		FileSystem(const FileSystem&) = delete;
+		FileSystem& operator=(const FileSystem&) = delete;
 
 		/// \brief gets the file system
 		/// \details throws an error when file system has

--- a/src/GenericIO.h
+++ b/src/GenericIO.h
@@ -75,6 +75,7 @@ template<class tag>
 class GenericIO
 {
 	public:
+        GenericIO() = default;
 		/// virtual d'tor to ensure correct cleanup
 		virtual ~GenericIO() = default;
 

--- a/src/GenericIO.h
+++ b/src/GenericIO.h
@@ -75,12 +75,12 @@ template<class tag>
 class GenericIO
 {
 	public:
-        GenericIO() = default;
+		GenericIO() = default;
 		/// virtual d'tor to ensure correct cleanup
 		virtual ~GenericIO() = default;
 
-        GenericIO(const GenericIO&) = delete;
-        GenericIO& operator=(const GenericIO&) = delete;
+		GenericIO(const GenericIO&) = delete;
+		GenericIO& operator=(const GenericIO&) = delete;
 
 		/// reads/writes one byte
 		virtual void byte ( typename detail::conster<tag, unsigned char>::type data) = 0;

--- a/src/GenericIO.h
+++ b/src/GenericIO.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <vector>
 #include <type_traits>
 
-#include <boost/noncopyable.hpp>
 #include <memory>
 
 #include "GenericIOFwd.h"
@@ -68,16 +67,19 @@ std::shared_ptr< GenericIn > createGenericReader(RakNet::BitStream* stream);
 			input and output have exactly the same interface and enables writing algorithms
 			that read and write data with exactly the same code, reducing the chance of
 			errors.
-			This class derives from boost::noncopyable, which seems a reasonable choice for these
+			This class is noncopyable, which seems a reasonable choice for these
 			IO classes. Having different GenericIO objects which read/write from/to the same source/target
 			just makes things more complicated and error prone.
 */
 template<class tag>
-class GenericIO : public boost::noncopyable
+class GenericIO
 {
 	public:
 		/// virtual d'tor to ensure correct cleanup
 		virtual ~GenericIO() = default;
+
+        GenericIO(const GenericIO&) = delete;
+        GenericIO& operator=(const GenericIO&) = delete;
 
 		/// reads/writes one byte
 		virtual void byte ( typename detail::conster<tag, unsigned char>::type data) = 0;

--- a/src/server/NetworkPlayer.h
+++ b/src/server/NetworkPlayer.h
@@ -22,7 +22,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <memory>
-#include <boost/noncopyable.hpp>
 
 #include "raknet/NetworkTypes.h"
 #include "raknet/BitStream.h"
@@ -38,7 +37,7 @@ class NetworkGame;
 		his network address and associated game
 */
 /// \todo add data to log when last packet arrived
-class NetworkPlayer : public ObjectCounter<NetworkPlayer>, public boost::noncopyable
+class NetworkPlayer : public ObjectCounter<NetworkPlayer>
 {
 	public:
 		NetworkPlayer();
@@ -46,6 +45,9 @@ class NetworkPlayer : public ObjectCounter<NetworkPlayer>, public boost::noncopy
 		NetworkPlayer(PlayerID id, const std::string& name, Color color, PlayerSide side);
 
 		NetworkPlayer(PlayerID id, RakNet::BitStream& stream);
+
+        NetworkPlayer(const NetworkPlayer&) = delete;
+        NetworkPlayer& operator=(const NetworkPlayer&) = delete;
 
 		bool valid() const;
 

--- a/src/server/NetworkPlayer.h
+++ b/src/server/NetworkPlayer.h
@@ -46,8 +46,8 @@ class NetworkPlayer : public ObjectCounter<NetworkPlayer>
 
 		NetworkPlayer(PlayerID id, RakNet::BitStream& stream);
 
-        NetworkPlayer(const NetworkPlayer&) = delete;
-        NetworkPlayer& operator=(const NetworkPlayer&) = delete;
+		NetworkPlayer(const NetworkPlayer&) = delete;
+		NetworkPlayer& operator=(const NetworkPlayer&) = delete;
 
 		bool valid() const;
 


### PR DESCRIPTION
This PR goes one step towards #45:
`boost::noncopyable` is no longer needed now that we can just `=delete` the copy c'tor and assignment operator. 
In principle, it might make sense to implement move operations for these classes, but I've skipped that for now.
