### PR TITLE
Getting rid of some more boost

### DIFF
--- a/src/File.h
+++ b/src/File.h
@@ -23,9 +23,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <string>
 #include <cinttypes>
 
-#include <boost/shared_array.hpp>
-
-
 #include "FileExceptions.h"
 #include "BlobbyDebug.h"
 

--- a/src/FileRead.cpp
+++ b/src/FileRead.cpp
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <physfs.h>
 
 #include <boost/crc.hpp>
-#include <boost/scoped_array.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include "tinyxml2.h"
@@ -72,12 +71,12 @@ uint32_t FileRead::readRawBytes( char* target, std::size_t num_of_bytes )
 	return num_read;
 }
 
-boost::shared_array<char> FileRead::readRawBytes( std::size_t num_of_bytes )
+std::vector<char> FileRead::readRawBytes( std::size_t num_of_bytes )
 {
 	// creates the buffer
-	boost::shared_array<char> buffer ( new char[num_of_bytes] );
+	std::vector<char> buffer ( num_of_bytes );
 
-	readRawBytes( buffer.get(), num_of_bytes );
+	readRawBytes( buffer.data(), num_of_bytes );
 	return buffer;
 }
 
@@ -241,14 +240,14 @@ XMLDocumentPtr FileRead::readXMLDocument(const std::string& filename)
 
 	// that's quite ugly
 	int fileLength = file.length();
-	boost::scoped_array<char> fileBuffer(new char[fileLength + 1]);
-	file.readRawBytes( fileBuffer.get(), fileLength );
+	std::vector<char> fileBuffer(fileLength + 1);
+	file.readRawBytes( fileBuffer.data(), fileLength );
 	// null-terminate
 	fileBuffer[fileLength] = 0;
 
 	// parse file
     XMLDocumentPtr xml = std::make_shared<tinyxml2::XMLDocument>();
-	xml->Parse(fileBuffer.get());
+	xml->Parse(fileBuffer.data());
 
 	/// \todo do error handling here?
 

--- a/src/FileRead.h
+++ b/src/FileRead.h
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "File.h"
 #include <memory>
+#include <vector>
  
 // forward declarations for convenience functions
 struct lua_State;
@@ -78,13 +79,13 @@ class FileRead : public File
 		uint32_t readRawBytes( char* target, std::size_t num_of_bytes );
 		
 		
-		/// reads bytes and returns a safe-pointed buffer
+		/// reads bytes and returns the buffer
 		/// the buffer is allocated by this function and has a size of \p num_of_bytes
 		/// \param num_of_bytes Number of bytes to read; size of buffer
 		/// \throw PhysfsFileException when nothing could be read
 		/// \throw NoFileOpenedException when called while no file is opened.
 		/// \throw EOFException when less than \p num_of_bytes bytes are available.
-		boost::shared_array<char> readRawBytes( std::size_t num_of_bytes );
+		std::vector<char> readRawBytes( std::size_t num_of_bytes );
 		
 		/// reads exactly one byte
 		/// \throw PhysfsFileException when Physfs reports an error

--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -97,9 +97,9 @@ SDL_Surface* RenderManager::loadSurface(const std::string& filename)
 	int fileLength = file.length();
 
 	// just read the whole file
-	boost::shared_array<char> fileContent = file.readRawBytes(fileLength);
+	auto fileContent = file.readRawBytes(fileLength);
 
-	SDL_RWops* rwops = SDL_RWFromMem(fileContent.get(), fileLength);
+	SDL_RWops* rwops = SDL_RWFromMem(fileContent.data(), fileLength);
 	SDL_Surface* newSurface = SDL_LoadBMP_RW(rwops , 1);
 
 	if (!newSurface)

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -57,7 +57,7 @@ namespace {
 		// read the entire file into memory
 		FileRead file(filename);
 		int fileLength = file.length();
-		boost::shared_array<char> fileBuffer = file.readRawBytes( fileLength );
+		auto fileBuffer = file.readRawBytes( fileLength );
 		file.close();
 
 		// prepare output variables
@@ -67,7 +67,7 @@ namespace {
 
 		// Do the actual file decoding.
 		// Note: rwops is always closed by this function
-		SDL_RWops* rwops = SDL_RWFromMem(fileBuffer.get(), fileLength);
+		SDL_RWops* rwops = SDL_RWFromMem(fileBuffer.data(), fileLength);
 		if (!SDL_LoadWAV_RW(rwops, 1, &newSoundSpec, &temp, &newSoundLength))
 			BOOST_THROW_EXCEPTION(FileLoadException(filename));
 

--- a/src/replays/ReplayPlayer.h
+++ b/src/replays/ReplayPlayer.h
@@ -22,8 +22,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "Global.h"
 #include "ReplayDefs.h"
 #include "PlayerInput.h"
@@ -98,7 +96,7 @@ class ReplayPlayer : public ObjectCounter<ReplayPlayer>
 
 		int mPosition;
 		int mLength;
-		boost::scoped_ptr<IReplayLoader> loader;
+		std::unique_ptr<IReplayLoader> loader;
 
 		std::string mPlayerNames[MAX_PLAYERS];
 };

--- a/src/server/NetworkGame.cpp
+++ b/src/server/NetworkGame.cpp
@@ -83,16 +83,13 @@ NetworkGame::NetworkGame(RakServer& server, NetworkPlayer& leftPlayer,
 	mRecorder->setGameRules(rules);
 
 	// read rulesfile into a string
-	int checksum = 0;
-	mRulesLength = 0;
 	mRulesSent[0] = false;
 	mRulesSent[1] = false;
 
 	rules = FileRead::makeLuaFilename( rules );
 	FileRead file(std::string("rules/") + rules);
-	checksum = file.calcChecksum(0);
-	mRulesLength = file.length();
-	mRulesString = file.readRawBytes(mRulesLength);
+	int checksum = file.calcChecksum(0);
+	mRulesString = file.readRawBytes(file.length());
 
 	// writing rules checksum
 	RakNet::BitStream stream;
@@ -285,8 +282,8 @@ void NetworkGame::processPacket( const packet_ptr& packet )
 			{
 				stream = std::make_shared<RakNet::BitStream>();
 				stream->Write((unsigned char)ID_RULES);
-				stream->Write( mRulesLength );
-				stream->Write( mRulesString.get(), mRulesLength);
+				stream->Write( (int)mRulesString.size() );
+				stream->Write( mRulesString.data(), mRulesString.size());
 				assert( stream->GetData()[0] == ID_RULES );
 
 				mServer.Send(stream.get(), HIGH_PRIORITY, RELIABLE_ORDERED, 0, packet->playerId, false);

--- a/src/server/NetworkGame.h
+++ b/src/server/NetworkGame.h
@@ -25,8 +25,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <thread>
 #include <memory>
 
-#include <boost/shared_array.hpp>
-
 #include "Global.h"
 #include "raknet/NetworkTypes.h"
 #include "raknet/BitStream.h"
@@ -106,7 +104,6 @@ class NetworkGame : public ObjectCounter<NetworkGame>
 		bool mGameValid;
 
 		bool mRulesSent[MAX_PLAYERS];
-		int mRulesLength;
-		boost::shared_array<char> mRulesString;
+		std::vector<char> mRulesString;
 };
 

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -24,7 +24,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <algorithm>
 #include <iostream>
 
-#include <boost/scoped_array.hpp>
 #include <utility>
 
 #include "raknet/RakClient.h"
@@ -254,12 +253,10 @@ void NetworkGameState::step_impl()
 				stream.Read(rulesLength);
 				if (rulesLength)
 				{
-					boost::shared_array<char>  rulesString( new char[rulesLength + 1] );
-					stream.Read(rulesString.get(), rulesLength);
-					// null terminate
-					rulesString[rulesLength] = 0;
+                    std::vector<char> rulesString(rulesLength + 1, '\0');
+					stream.Read(rulesString.data(), rulesLength);
 					FileWrite rulesFile("rules/"+TEMP_RULES_NAME);
-					rulesFile.write(rulesString.get(), rulesLength);
+					rulesFile.write(rulesString.data(), rulesLength);
 					rulesFile.close();
 					mMatch->setRules(TEMP_RULES_NAME);
 				}


### PR DESCRIPTION
Replaces buffers managed as boost smart pointers with `std::vector`
While this has a performance implication (std::vector initializes its memory), this is negligible in our case.