### PR TITLE
changed include path for SDL headers

### DIFF
--- a/src/Clock.cpp
+++ b/src/Clock.cpp
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* includes */
 #include <sstream>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /* implementation */
 

--- a/src/Global.h
+++ b/src/Global.h
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <exception>
-#include <SDL2/SDL_stdinc.h>
+#include <SDL_stdinc.h>
 #include <cstring>
 #include <utility>
 

--- a/src/IMGUI.cpp
+++ b/src/IMGUI.cpp
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <queue>
 #include <cassert>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /* implementation */
 

--- a/src/InputDevice.h
+++ b/src/InputDevice.h
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #pragma once
 
-#include <SDL2/SDL_events.h>
+#include <SDL_events.h>
 #include "PlayerInput.h"
 #include "BlobbyDebug.h"
 

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <cassert>
 #include <iostream>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "UserConfig.h"
 #include "RenderManager.h"

--- a/src/InputManager.h
+++ b/src/InputManager.h
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <memory>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "PlayerInput.h"
 #include "Vector.h"

--- a/src/RenderManager.h
+++ b/src/RenderManager.h
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #pragma once
 
 #include <map>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "Vector.h"
 #include "Global.h"

--- a/src/RenderManagerGL2D.h
+++ b/src/RenderManagerGL2D.h
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #if HAVE_LIBGL
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #if __MACOSX__
 #include <OpenGL/gl.h>

--- a/src/RenderManagerSDL.h
+++ b/src/RenderManagerSDL.h
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <vector>
 
 #include "RenderManager.h"

--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <iostream>
 #include <boost/exception/all.hpp>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 extern "C"
 {

--- a/src/SoundManager.h
+++ b/src/SoundManager.h
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <string>
 #include <map>
 #include <vector>

--- a/src/SpeedController.cpp
+++ b/src/SpeedController.cpp
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* includes */
 #include <algorithm>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /* implementation */
 /// this is required to reduce rounding errors. now we have a resolution of

--- a/src/input_device/JoystickPool.cpp
+++ b/src/input_device/JoystickPool.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <sstream>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <InputManager.h>
 

--- a/src/input_device/JoystickPool.h
+++ b/src/input_device/JoystickPool.h
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <map>
 #include <string>
 
-#include <SDL2/SDL_events.h>
+#include <SDL_events.h>
 
 #include "BlobbyDebug.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <thread>
 #include <iostream>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "Global.h"
 

--- a/src/runtest.cpp
+++ b/src/runtest.cpp
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <thread>
 #include <iostream>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "Global.h"
 

--- a/src/server/servermain.cpp
+++ b/src/server/servermain.cpp
@@ -34,8 +34,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
-#include <SDL2/SDL_timer.h>
-
 #include "DedicatedServer.h"
 #include "SpeedController.h"
 #include "FileSystem.h"


### PR DESCRIPTION
currently, we are including SDL headers as `<SDL2/$HEADER.h>`
This works, because the "SDL2" directory is in `/usr/include`, so in the default search path.
The actual search path we add based on `SDL_INCLUDE_DIRECTORIES` is `/usr/include/SDL2`.
This distinction becomes important in cases where SDL2 is not in a default location, such as when we're building it ourselves, e.g. for android CI. Therefore, this PR changes all includes to be relative to `SDL_INCLUDE_DIRECTORIES`