### PR TITLE
IScriptableComponent cleanup

### DIFF
--- a/src/Global.h
+++ b/src/Global.h
@@ -139,20 +139,6 @@ struct Color
 
 };
 
-
-struct ExtensionUnsupportedException : public std::exception
-{
-	std::string extension;
-	explicit ExtensionUnsupportedException(std::string name) : extension(std::move(name)) {}
-	~ExtensionUnsupportedException() noexcept override = default;
-};
-
-struct ScriptException : public std::exception
-{
-	std::string luaerror;
-	~ScriptException() noexcept override = default;
-};
-
 /// we need to define this constant to make it compile with strict c++98 mode
 #undef M_PI
 const double M_PI = 3.141592653589793238462643383279;

--- a/src/IScriptableComponent.cpp
+++ b/src/IScriptableComponent.cpp
@@ -7,6 +7,7 @@
 #include "DuelMatch.h"
 #include "DuelMatchState.h"
 #include "FileRead.h"
+#include "PhysicWorld.h"
 
 #include <iostream>
 
@@ -14,7 +15,7 @@
 int lua_print(lua_State* state);
 
 IScriptableComponent::IScriptableComponent() :
-	mState(luaL_newstate())
+		mState(luaL_newstate()), mDummyWorld(new PhysicWorld())
 {
 	// register this in the lua registry
 	lua_pushliteral(mState, "__C++_ScriptComponent__");
@@ -149,7 +150,7 @@ struct IScriptableComponent::Access
 	static PhysicWorld* getWorld( lua_State* state )
 	{
 		auto sc = getScriptComponent( state );
-		return &sc->mDummyWorld;
+		return sc->mDummyWorld.get();
 	}
 };
 
@@ -350,9 +351,9 @@ int lua_print(lua_State* state)
 		const char* str = lua_tostring(state, -1);
 		std::cout << (i != 1 ? ", " : "");
 		if(str)
-		 std::cout << str;
+			std::cout << str;
 		else
-		std::cout << "[" << lua_typename(state, lua_type(state, -1)) << "]";
+			std::cout << "[" << lua_typename(state, lua_type(state, -1)) << "]";
 	}
 	std::cout << "\n";
 	lua_pop(state, lua_gettop(state));
@@ -373,9 +374,9 @@ void IScriptableComponent::setGameFunctions()
 	lua_register(mState, "simulate", simulate_steps);
 	lua_register(mState, "simulate_until", simulate_until);
 
-	#ifndef NDEBUG
+#ifndef NDEBUG
 	// only enable this function in debug builds.
 	lua_register(mState, "set_ball_data", set_ball_data);
 	lua_register(mState, "set_blob_data", set_blob_data);
-	#endif
+#endif
 }

--- a/src/IScriptableComponent.h
+++ b/src/IScriptableComponent.h
@@ -27,6 +27,13 @@ struct lua_State;
 class DuelMatch;
 class PhysicWorld;
 
+struct ScriptException : public std::exception
+{
+	std::string luaerror;
+	~ScriptException() noexcept override = default;
+};
+
+
 /*! \class IScriptableComponent
 	\brief Base class for lua scripted objects.
 	\details Use this class as base class for objects that support lua scripting. It defines some commonly used functions to make

--- a/src/IScriptableComponent.h
+++ b/src/IScriptableComponent.h
@@ -21,10 +21,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #pragma once
 
 #include <string>
-#include "PhysicWorld.h"
+#include <memory>
 
 struct lua_State;
 class DuelMatch;
+class PhysicWorld;
 
 /*! \class IScriptableComponent
 	\brief Base class for lua scripted objects.
@@ -33,30 +34,30 @@ class DuelMatch;
 */
 class IScriptableComponent
 {
-public:
-	struct Access;
-protected:
-	IScriptableComponent();
-	virtual ~IScriptableComponent();
+	public:
+		struct Access;
+	protected:
+		IScriptableComponent();
+		virtual ~IScriptableComponent();
 
-	void openScript(const std::string& file);
-	void setLuaGlobal(const char* name, double value);
-	bool getLuaFunction(const char* name) const;
+		void openScript(const std::string& file);
+		void setLuaGlobal(const char* name, double value);
+		bool getLuaFunction(const char* name) const;
 
-	// calls a lua function that is on the stack and performs error handling
-	void callLuaFunction(int arg_count = 0);
+		// calls a lua function that is on the stack and performs error handling
+		void callLuaFunction(int arg_count = 0);
 
-	// load lua functions
-	void setGameConstants();
-	void setGameFunctions();
-	void setMatch( DuelMatch* m ) { mGame = m; };
-	DuelMatch* getMatch() const { return mGame; };
+		// load lua functions
+		void setGameConstants();
+		void setGameFunctions();
+		void setMatch( DuelMatch* m ) { mGame = m; };
+		DuelMatch* getMatch() const { return mGame; };
 
-	lua_State* mState;
+		lua_State* mState;
 
-private:
-	DuelMatch* mGame;
-	// we save a dummy physic world here to do simulations
-	PhysicWorld mDummyWorld;
+	private:
+		DuelMatch* mGame;
+		// we save a dummy physic world here to do simulations
+		std::unique_ptr<PhysicWorld> mDummyWorld;
 };
 

--- a/src/state/State.cpp
+++ b/src/state/State.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "TextManager.h"
 #include "SpeedController.h"
 #include "InputManager.h"
-
+#include "IScriptableComponent.h"
 
 /* implementation */
 


### PR DESCRIPTION
Some more cleanup as a result of working on #48.
This removes the public dependency of `IScriptableComponent` on `PhysicsWorld`, and also moves the `ScriptException` from `Global.h` to `IScriptableComponent.h`