### PR TITLE
clock code based on `<chrono>`

### DIFF
--- a/src/Clock.cpp
+++ b/src/Clock.cpp
@@ -24,42 +24,47 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* includes */
 #include <sstream>
 
-#include <SDL.h>
-
 /* implementation */
+
+namespace {
+	template<class T>
+	Clock::seconds to_seconds(T input) {
+		return std::chrono::duration_cast<Clock::seconds>(input);
+	}
+}
 
 void Clock::reset()
 {
 	// set all variables to their default values
 	mRunning = false;
-	mGameRunning = milliseconds(0);
-	mLastTime = milliseconds{SDL_GetTicks()};
+	mGameRunning = duration_t(0);
+	mLastTime = clock_t::now();
 }
 
 void Clock::start()
 {
-	mLastTime = milliseconds{SDL_GetTicks()};
+	mLastTime = clock_t::now();
 	mRunning = true;
 }
 
-void Clock::stop() 
+void Clock::stop()
 {
 	mRunning = false;
 }
 
-bool Clock::isRunning() const 
+bool Clock::isRunning() const
 {
 	return mRunning;
 }
 
 Clock::seconds Clock::getTime() const
 {
-	return std::chrono::duration_cast<seconds>(mGameRunning);
+	return to_seconds(mGameRunning);
 }
 
-void Clock::setTime(seconds newTime)
+void Clock::setTime(milliseconds newTime)
 {
-	updateGameTime(newTime * 1000);
+	updateGameTime(newTime);
 }
 
 std::string Clock::makeTimeString(seconds time)
@@ -103,19 +108,16 @@ void Clock::step()
 {
 	if(mRunning)
 	{
-		milliseconds newTime{SDL_GetTicks()};
-		if(newTime > mLastTime)
-		{
-			updateGameTime(mGameRunning + newTime - mLastTime);
-		}
+		auto newTime = clock_t::now();
+		updateGameTime(mGameRunning + (newTime - mLastTime));
 		mLastTime = newTime;
 	}
 }
 
-void Clock::updateGameTime(std::chrono::milliseconds newTime) {
-	auto old_sec = std::chrono::duration_cast<seconds>(mGameRunning);
-	auto new_sec = std::chrono::duration_cast<seconds>(newTime);
-	mGameRunning = newTime;
+void Clock::updateGameTime(duration_t new_time) {
+	auto old_sec = to_seconds( mGameRunning );
+	auto new_sec = to_seconds( new_time);
+	mGameRunning = new_time;
 
 	// update time string only when the seconds change.
 	if(old_sec != new_sec) {

--- a/src/Clock.h
+++ b/src/Clock.h
@@ -33,52 +33,54 @@ class Clock
 	public:
 		using seconds = std::chrono::seconds;
 		using milliseconds = std::chrono::milliseconds;
+		using clock_t = std::chrono::steady_clock;
+		using duration_t = clock_t::duration;
 
 		/// default c'tor
 		Clock() = default;
-		
+
 		/// starts/unpauses the clock
 		void start();
 		/// pauses the clock
 		void stop();
-				
+
 		/// resets the clock. after this, the clock is paused.
 		void reset();
-		
+
 		/// gets whether the clock is currently running
 		bool isRunning() const;
-		
+
 		/// this function has to be called each frame. It calculates
 		///	the passed time;
 		void step();
-		
+
 		/// gets the time in seconds as an integer
 		seconds getTime() const;
-		
+
 		/// set the time to a specified value
-		/// \param newTime: new time in seconds
-		void setTime(seconds newTime);
-		
+		/// \param newTime: new time in milliseconds
+		void setTime(milliseconds newTime);
+
 		/// returns the time as a string
 		const std::string& getTimeString() const;
-		
+
 	private:
 		/// is the clock currently running?
 		bool mRunning{false};
-		
+
 		/// recorded time in milliseconds. Do not write to this directly, but use
 		/// `updateGameTime` to ensure synchronization with `mCurrentTimeString`
-		milliseconds mGameRunning{0};
-		
-		/// last time that step was called. 
+		duration_t mGameRunning{0};
+
+		/// last time that step was called.
 		/// needed to calculate the time difference.
-		milliseconds mLastTime{0};
+		clock_t::time_point mLastTime;
 
 		/// Currently formatted time text
 		std::string mCurrentTimeString;
 
 		/// Sets the new game time, and updates `mCurrentTimeString` if appropriate.
-		void updateGameTime(milliseconds newTime);
+		void updateGameTime(duration_t new_time);
 
 		/// Formats the given amount of seconds into a time string.
 		static std::string makeTimeString(seconds time);

--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "GameConstants.h"
 #include "InputSource.h"
 #include "IUserConfigReader.h"
+#include "Clock.h"
 
 /* implementation */
 
@@ -288,14 +289,14 @@ void DuelMatch::setServingPlayer(PlayerSide side)
 	mLogic->onServe( );
 }
 
-const Clock& DuelMatch::getClock() const
+const std::string& DuelMatch::getTimeString() const
 {
-	return mLogic->getClock();
+	return mLogic->getClock().getTimeString();
 }
 
-Clock& DuelMatch::getClock()
+void DuelMatch::setMatchTimeMs(int milliseconds)
 {
-	return mLogic->getClock();
+	mLogic->getClock().setTime( Clock::milliseconds(milliseconds) );
 }
 
 std::shared_ptr<InputSource> DuelMatch::getInputSource(PlayerSide player) const

--- a/src/DuelMatch.h
+++ b/src/DuelMatch.h
@@ -91,8 +91,10 @@ class DuelMatch : public ObjectCounter<DuelMatch>
 		Vector2 getBlobVelocity(PlayerSide player) const;
 
 		const PhysicWorld& getWorld() const{ return *mPhysicWorld; };
-		const Clock& getClock() const;
-		Clock& getClock();
+
+		// Timing
+		const std::string& getTimeString() const;
+		void setMatchTimeMs(int milliseconds);
 
 		bool getBallDown() const;
 		bool getBallActive() const;

--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -106,7 +106,7 @@ void GameState::presentGameUI()
 	// blob name / time textfields
 	imgui.doText(GEN_ID, Vector2(12, 550), mMatch->getPlayer(LEFT_PLAYER).getName());
 	imgui.doText(GEN_ID, Vector2(788, 550), mMatch->getPlayer(RIGHT_PLAYER).getName(), TF_ALIGN_RIGHT);
-	imgui.doText(GEN_ID, Vector2(400, 24), mMatch->getClock().getTimeString(), TF_ALIGN_CENTER);
+	imgui.doText(GEN_ID, Vector2(400, 24), mMatch->getTimeString(), TF_ALIGN_CENTER);
 }
 
 

--- a/src/state/ReplayState.cpp
+++ b/src/state/ReplayState.cpp
@@ -32,7 +32,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "ReplaySelectionState.h"
 #include "InputManager.h"
 #include "FileWrite.h"
-#include "Clock.h"
 
 /* implementation */
 
@@ -123,7 +122,7 @@ void ReplayState::step_impl()
 
 	}
 
-	mMatch->getClock().setTime( Clock::seconds{mReplayPlayer->getReplayPosition() / mReplayPlayer->getGameSpeed()} );
+	mMatch->setMatchTimeMs( 1000 * mReplayPlayer->getReplayPosition() / mReplayPlayer->getGameSpeed() );
 
 	// draw the progress bar
 	Vector2 prog_pos = Vector2(50, 600-22);


### PR DESCRIPTION
One more change extracted from #48
This bases the implementation of `Clock` on `<chrono>` instead of `SDL_GetTicks`
It also reduces the number of direct dependants on `Clock` by adding utility methods to `DuelMatch`
While these changes are only truly useful in conjuction with the modularization #48, I think they are also good taken by themselves.