### PR TITLE
split color definition out of global header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(common_SRC
 	GameLogic.cpp GameLogic.h
 	GenericIO.cpp GenericIO.h
 	Global.h
+	Color.cpp Color.h
 	NetworkMessage.cpp NetworkMessage.h
 	PhysicWorld.cpp PhysicWorld.h
 	SpeedController.cpp SpeedController.h

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -1,7 +1,8 @@
 /*=============================================================================
 Blobby Volley 2
 Copyright (C) 2006 Jonathan Sieber (jonathan_sieber@yahoo.de)
-Copyright (C) 2006 Daniel Knobe (daniel-knobe@web.de)
+Copyright (C) 2022 Daniel Knobe (daniel-knobe@web.de)
+Copyright (C) 2022 Erik Schultheis (erik-schultheis@freenet.de)
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -18,33 +19,31 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 =============================================================================*/
 
-#pragma once
-
-#include <string>
-
-#include "Global.h"
+/* header include */
 #include "Color.h"
 
-class PlayerIdentity
+/* includes */
+
+/* implementation */
+
+Color::Color(int red, int green, int blue)
+		: r(red)
+		, g(green)
+		, b(blue)
 {
-	public:
-		PlayerIdentity() = default;
-		explicit PlayerIdentity(std::string name);
-		PlayerIdentity(std::string name, Color color, bool osci, PlayerSide pref);
 
-		const std::string& getName() const;
-		Color getStaticColor() const;
-		bool getOscillating() const;
-		PlayerSide getPreferredSide() const;
+}
 
-		void setName(const std::string& nname);
-		void setStaticColor(Color ncol);
-		void setOscillating(bool oc);
-		void setPreferredSide(PlayerSide side);
+Color::Color(unsigned int col) : Color(col&0xff, (col>>8)&0xff, (col>>16)&0xff)
+{
 
-	private:
-		std::string mName;
-		Color mStaticColor;
-		bool mOscillating;
-		PlayerSide mPreferredSide;
-};
+}
+
+unsigned int Color::toInt() const
+{
+	int i = 0;
+	i |= r;
+	i |= g << 8;
+	i |= b << 16;
+	return i;
+}

--- a/src/Color.h
+++ b/src/Color.h
@@ -1,7 +1,8 @@
 /*=============================================================================
 Blobby Volley 2
 Copyright (C) 2006 Jonathan Sieber (jonathan_sieber@yahoo.de)
-Copyright (C) 2006 Daniel Knobe (daniel-knobe@web.de)
+Copyright (C) 2022 Daniel Knobe (daniel-knobe@web.de)
+Copyright (c) 2022 Erik Schultheis (erik-schultheis@freenet.de)
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -20,31 +21,36 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #pragma once
 
-#include <string>
+#include <cstdint>
 
-#include "Global.h"
-#include "Color.h"
-
-class PlayerIdentity
+/*! \class Color
+	\brief represents RGB Colours
+	\details This class represents colors as RGB with one byte for each channel.
+*/
+struct Color
 {
 	public:
-		PlayerIdentity() = default;
-		explicit PlayerIdentity(std::string name);
-		PlayerIdentity(std::string name, Color color, bool osci, PlayerSide pref);
+		Color(int red, int green, int blue);
 
-		const std::string& getName() const;
-		Color getStaticColor() const;
-		bool getOscillating() const;
-		PlayerSide getPreferredSide() const;
+		/// \sa toInt()
+		explicit Color(unsigned int col);
 
-		void setName(const std::string& nname);
-		void setStaticColor(Color ncol);
-		void setOscillating(bool oc);
-		void setPreferredSide(PlayerSide side);
+		Color() = default;
 
-	private:
-		std::string mName;
-		Color mStaticColor;
-		bool mOscillating;
-		PlayerSide mPreferredSide;
+		bool operator == (Color rval) const
+		{
+			return r == rval.r && g == rval.g && b == rval.b;
+		}
+
+		bool operator != (Color rval) const
+		{
+			return !(*this == rval);
+		}
+
+		unsigned int toInt() const;
+
+		std::uint8_t r = 0;
+		std::uint8_t g = 0;
+		std::uint8_t b = 0;
+
 };

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <physfs.h>
 
-#include "Global.h"
 #include "FileSystem.h"
 
 /* implementation */

--- a/src/FileRead.cpp
+++ b/src/FileRead.cpp
@@ -33,8 +33,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "lua/lua.hpp"
 
-#include "Global.h"
-
 
 /* implementation */
 

--- a/src/FileWrite.cpp
+++ b/src/FileWrite.cpp
@@ -26,8 +26,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <physfs.h>
 
-#include "Global.h"
-
 
 /* implementation */
 

--- a/src/GenericIO.cpp
+++ b/src/GenericIO.cpp
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "FileWrite.h"
 #include "FileRead.h"
 #include "PlayerInput.h"
+#include "Color.h"
 
 // -------------------------------------------------------------------------------------------------
 //							File Output Class

--- a/src/GenericIO.h
+++ b/src/GenericIO.h
@@ -29,7 +29,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "GenericIOFwd.h"
 #include "GenericIODetail.h"
-#include "Global.h"
 
 // forward declarations
 

--- a/src/Global.h
+++ b/src/Global.h
@@ -22,7 +22,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <exception>
-#include <SDL_stdinc.h>
 #include <cstring>
 #include <utility>
 
@@ -74,69 +73,7 @@ enum PlayerSide
 	//LEFT_PLAYER_2 = 2,
 	//RIGHT_PLAYER_2 = 3,
 	MAX_PLAYERS // This is always one more than the highest player enum
-	            // and can be used to declare arrays
-};
-
-enum InputDeviceName
-{
-	KEYBOARD = 1,
-	MOUSE = 2,
-	JOYSTICK = 3
-};
-
-/*! \class Color
-	\brief represents RGB Colours
-	\details This class represents colors as RGB with one byte for each channel.
-*/
-struct Color
-{
-	Color(int red, int green, int blue)
-	: r(red)
-	, g(green)
-	, b(blue)
-	{}
-
-	/// \sa toInt()
-	explicit Color(unsigned int col)
-	: r(col&0xff)
-	, g((col>>8)&0xff)
-	, b((col>>16)&0xff)
-	{
-
-	}
-
-	Color() = default;
-
-	union
-	{
-		struct
-		{
-			Uint8 r;
-			Uint8 g;
-			Uint8 b;
-		};
-		Uint8 val[3];
-	};
-
-	bool operator == (Color rval) const
-	{
-		return !std::memcmp(val, rval.val, 3);
-	}
-
-	bool operator != (Color rval) const
-	{
-		return !(*this == rval);
-	}
-
-	unsigned int toInt() const
-	{
-		int i = 0;
-		i |= r;
-		i |= g << 8;
-		i |= b << 16;
-		return i;
-	}
-
+	// and can be used to declare arrays
 };
 
 /// we need to define this constant to make it compile with strict c++98 mode

--- a/src/RenderManager.h
+++ b/src/RenderManager.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <SDL.h>
 
 #include "Vector.h"
-#include "Global.h"
+#include "Color.h"
 #include "BlobbyDebug.h"
 
 
@@ -56,7 +56,7 @@ static const int TF_ALIGN_RIGHT = 0x10;	// Text aligned right
 /*! \struct BufferedImage
 	\brief image data
 	\details couples the raw image data with its size in a way that is
-			independend of the used renderer.
+			independent of the used renderer.
 */
 struct BufferedImage : public ObjectCounter<BufferedImage>
 {

--- a/src/RenderManagerGL2D.cpp
+++ b/src/RenderManagerGL2D.cpp
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* includes */
 #include "FileExceptions.h"
+#include "Color.h"
+#include "Global.h"
 
 /* implementation */
 RenderManagerGL2D::Texture::Texture( GLuint tex, int x, int y, int width, int height, int tw, int th ) :
@@ -106,14 +108,14 @@ GLuint RenderManagerGL2D::loadTexture(SDL_Surface *surface, bool specular)
 	targetRect.y = (paddedY - oldY) / 2;
 
 	SDL_SetColorKey(textureSurface, SDL_TRUE,
-			SDL_MapRGB(textureSurface->format, 0, 0, 0));
+	                SDL_MapRGB(textureSurface->format, 0, 0, 0));
 	convertedTexture =
-		SDL_CreateRGBSurface(SDL_SWSURFACE,
-			paddedX, paddedY, 32,
+	        SDL_CreateRGBSurface(SDL_SWSURFACE,
+	                             paddedX, paddedY, 32,
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-			0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+	                0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
 #else
-			0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+	                0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
 #endif
 	SDL_BlitSurface(textureSurface, nullptr, convertedTexture, &targetRect);
 
@@ -124,8 +126,8 @@ GLuint RenderManagerGL2D::loadTexture(SDL_Surface *surface, bool specular)
 			for (int x = 0; x < convertedTexture->w; ++x)
 			{
 				SDL_Color* pixel =
-					&(((SDL_Color*)convertedTexture->pixels)
-					[y * convertedTexture->w +x]);
+				        &(((SDL_Color*)convertedTexture->pixels)
+				        [y * convertedTexture->w +x]);
 				int luminance = int(pixel->r) * 5 - 4 * 256 - 138;
 				luminance = luminance > 0 ? luminance : 0;
 				luminance = luminance < 255 ? luminance : 255;
@@ -142,8 +144,8 @@ GLuint RenderManagerGL2D::loadTexture(SDL_Surface *surface, bool specular)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8,
-			convertedTexture->w, convertedTexture->h, 0, GL_RGBA,
-			GL_UNSIGNED_BYTE, convertedTexture->pixels);
+	             convertedTexture->w, convertedTexture->h, 0, GL_RGBA,
+	             GL_UNSIGNED_BYTE, convertedTexture->pixels);
 	SDL_FreeSurface(textureSurface);
 	SDL_FreeSurface(convertedTexture);
 
@@ -219,15 +221,15 @@ void RenderManagerGL2D::init(int xResolution, int yResolution, bool fullscreen)
 
 	// Create window
 	mWindow = SDL_CreateWindow(AppTitle,
-		SDL_WINDOWPOS_UNDEFINED,
-		SDL_WINDOWPOS_UNDEFINED,
-		xResolution, yResolution,
-		screenFlags);
+	                           SDL_WINDOWPOS_UNDEFINED,
+	                           SDL_WINDOWPOS_UNDEFINED,
+	                           xResolution, yResolution,
+	                           screenFlags);
 
 	// Set icon
 	SDL_Surface* icon = loadSurface("Icon.bmp");
 	SDL_SetColorKey(icon, SDL_TRUE,
-			SDL_MapRGB(icon->format, 0, 0, 0));
+	                SDL_MapRGB(icon->format, 0, 0, 0));
 	SDL_SetWindowIcon(mWindow, icon);
 	SDL_FreeSurface(icon);
 
@@ -411,7 +413,7 @@ void RenderManagerGL2D::draw()
 
 		Vector2& ballPosition = *iter;
 */
-		drawQuad(mBallPosition.x, mBallPosition.y, 64.0, 64.0);
+	drawQuad(mBallPosition.x, mBallPosition.y, 64.0, 64.0);
 
 /*
 		opacity += 0.1;
@@ -424,12 +426,12 @@ void RenderManagerGL2D::draw()
 	// blob normal
 	// left blob
 	glBindTexture(mBlob[int(mLeftBlobAnimationState)  % 5]);
-	glColor3ubv(mLeftBlobColor.val);
+	glColor3ub(mLeftBlobColor.r, mLeftBlobColor.g, mLeftBlobColor.b);
 	drawQuad(mLeftBlobPosition.x, mLeftBlobPosition.y, 128.0, 128.0);
 
 	// right blob
 	glBindTexture(mBlob[int(mRightBlobAnimationState)  % 5]);
-	glColor3ubv(mRightBlobColor.val);
+	glColor3ub(mRightBlobColor.r, mRightBlobColor.g, mRightBlobColor.b);
 	drawQuad(mRightBlobPosition.x, mRightBlobPosition.y, 128.0, 128.0);
 
 	// blob specular
@@ -615,10 +617,10 @@ void RenderManagerGL2D::drawOverlay(float opacity, Vector2 pos1, Vector2 pos2, C
 	glColor4f(col.r, col.g, col.b, opacity);
 	//glLoadIdentity();
 	glBegin(GL_QUADS);
-		glVertex2f(pos1.x, pos1.y);
-		glVertex2f(pos1.x, pos2.y);
-		glVertex2f(pos2.x, pos2.y);
-		glVertex2f(pos2.x, pos1.y);
+	glVertex2f(pos1.x, pos1.y);
+	glVertex2f(pos1.x, pos2.y);
+	glVertex2f(pos2.x, pos2.y);
+	glVertex2f(pos2.x, pos1.y);
 	glEnd();
 }
 
@@ -633,7 +635,7 @@ void RenderManagerGL2D::drawBlob(const Vector2& pos, const Color& col)
 	//glLoadIdentity();
 	//glTranslatef(pos.x, pos.y, 0.6);
 	glBindTexture(mBlob[0]);
-	glColor3ubv(col.val);
+	glColor3ub(col.r, col.g, col.b);
 	drawQuad(pos.x, pos.y, 128.0, 128.0);
 
 	glEnable(GL_BLEND);
@@ -660,11 +662,11 @@ void RenderManagerGL2D::drawParticle(const Vector2& pos, int player)
 	//glTranslatef(pos.x, pos.y, 0.6);
 
 	if (player == LEFT_PLAYER)
-		glColor3ubv(mLeftBlobColor.val);
+		glColor3ub(mLeftBlobColor.r, mLeftBlobColor.b, mLeftBlobColor.g);
 	if (player == RIGHT_PLAYER)
-		glColor3ubv(mRightBlobColor.val);
+		glColor3ub(mRightBlobColor.r, mRightBlobColor.b, mRightBlobColor.g);
 	if (player > 1)
-		glColor3ubv(Color(255, 0, 0).val);
+		glColor3ub(255, 0, 0);
 
 	float w = 16.0;
 	float h = 16.0;

--- a/src/RenderManagerSDL.h
+++ b/src/RenderManagerSDL.h
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <vector>
 
 #include "RenderManager.h"
+#include "Global.h"
 
 /*! \class RenderManagerSDL
 	\brief Render Manager on top of SDL

--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -22,19 +22,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "ScriptedInputSource.h"
 
 /* includes */
-#include <cmath>
 #include <algorithm>
 #include <iostream>
 #include <boost/exception/all.hpp>
 
 #include <SDL.h>
 
-extern "C"
-{
-#include "lua/lua.h"
-#include "lua/lauxlib.h"
-#include "lua/lualib.h"
-}
+#include "lua/lua.hpp"
 
 #include "DuelMatch.h"
 #include "IUserConfigReader.h"

--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <iostream>
 #include <cassert>
 
-#include "Global.h"
 #include "FileRead.h"
 
 /* implementation */

--- a/src/replays/IReplayLoader.h
+++ b/src/replays/IReplayLoader.h
@@ -23,12 +23,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <ctime>	// for time_t
 #include <memory>
 
-#include "Global.h"
 #include "ReplaySavePoint.h"
 #include "BlobbyDebug.h"
 #include "GenericIOFwd.h"
 
 struct PlayerInput;
+struct Color;
 class InputSource;
 
 /// \class IReplayLoader

--- a/src/replays/ReplayLoader.cpp
+++ b/src/replays/ReplayLoader.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "GenericIO.h"
 #include "base64.h"
 #include "ReplayDefs.h"
+#include "Color.h"
 
 /* implementation */
 IReplayLoader* IReplayLoader::createReplayLoader(const std::string& filename)

--- a/src/replays/ReplayPlayer.h
+++ b/src/replays/ReplayPlayer.h
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 
-#include "Global.h"
+#include "Color.h"
 #include "ReplayDefs.h"
 #include "PlayerInput.h"
 #include "BlobbyDebug.h"

--- a/src/replays/ReplayRecorder.h
+++ b/src/replays/ReplayRecorder.h
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <memory>
 
-#include "Global.h"
+#include "Color.h"
 #include "ReplaySavePoint.h"
 #include "PlayerInput.h"
 #include "BlobbyDebug.h"

--- a/src/state/GameState.h
+++ b/src/state/GameState.h
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "State.h"
 #include "TextManager.h"
+#include "Global.h"
 
 #include <functional>
 #include <tuple>

--- a/src/state/State.h
+++ b/src/state/State.h
@@ -20,8 +20,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #pragma once
 
-#include "Global.h"
-
 #include <memory>
 
 class DuelMatch;


### PR DESCRIPTION
This change moves the `Color` helper struct out of the global header and into its own files. 