### PR TITLE
Decoupling of rendering and game state

### DIFF
--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -34,7 +34,6 @@ RenderManager* RenderManager::mSingleton = nullptr;
 RenderManager::~RenderManager() = default;
 
 RenderManager::RenderManager() :
-	mDrawGame(false),
 	mBloodMgr(new BloodManager(IUserConfigReader::createUserConfigReader("config.xml")->getBool("blood")))
 {
 	//assert(!mSingleton);
@@ -334,11 +333,6 @@ SDL_Rect RenderManager::blobShadowRect(const Vector2& position)
 		32
 	};
 	return rect;
-}
-
-void RenderManager::drawGame(bool draw)
-{
-	mDrawGame = draw;
 }
 
 void RenderManager::setTitle(const std::string& title)

--- a/src/RenderManager.h
+++ b/src/RenderManager.h
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 class BloodManager;
+struct DuelMatchState;
 
 // Text definitions
 static const int FONT_WIDTH_NORMAL 	=	24;	// Height and width of the normal font.
@@ -112,9 +113,6 @@ class RenderManager : public ObjectCounter<RenderManager>
 		Color getOscillationColor() const;
 		BloodManager& getBlood();
 
-		// Draws the stuff
-		virtual void draw() = 0;
-
 		// This swaps the screen buffers and should be called
 		// after all draw calls
 		virtual void refresh() {};
@@ -127,7 +125,7 @@ class RenderManager : public ObjectCounter<RenderManager>
 		virtual void deinit() {};
 
 		// Set a background image by filename
-		// Note: There is a default, you dont need to do this
+		// Note: There is a default, you don't need to do this
 		// Returns true on success
 		virtual bool setBackground(const std::string& filename) { return true; };
 
@@ -135,14 +133,6 @@ class RenderManager : public ObjectCounter<RenderManager>
 		virtual void setBlobColor(int player, Color color) {};
 
 		virtual void showShadow(bool shadow) {};
-
-		// Takes the new balls position and its rotation in radians
-		virtual void setBall(const Vector2& position, float rotation) {};
-
-		// Takes the new position and the animation state as a float,
-		// because some renderers may interpolate the animation
-		virtual void setBlob(int player, const Vector2& position,
-				float animationState) {};
 
 		virtual void setMouseMarker(float position);
 
@@ -158,8 +148,11 @@ class RenderManager : public ObjectCounter<RenderManager>
 		// This draws a greyed-out area
 		virtual void drawOverlay(float opacity, Vector2 pos1, Vector2 pos2, Color col = Color(0,0,0)) {}
 
-		//Draws a blob
+		// Draws a blob
 		virtual void drawBlob(const Vector2& pos, const Color& col){};
+
+		// Draws the game
+		virtual void drawGame(const DuelMatchState& gameState) = 0;
 
 		// Enables particle drawing
 		virtual void startDrawParticles() {};
@@ -167,10 +160,6 @@ class RenderManager : public ObjectCounter<RenderManager>
 		virtual void drawParticle(const Vector2& pos, int player){};
 		// Finishes drawing particles
 		virtual void endDrawParticles() {};
-
-		// This can disable the rendering of ingame graphics, for example for
-		// the main menu
-		void drawGame(bool draw);
 
 		// This function may be useful for displaying framerates
 		void setTitle(const std::string& title);
@@ -195,8 +184,6 @@ class RenderManager : public ObjectCounter<RenderManager>
 		SDL_Rect blobShadowRect(const Vector2& position);
 		SDL_Rect ballRect(const Vector2& position);
 		SDL_Rect ballShadowRect(const Vector2& position);
-
-		bool mDrawGame;
 
 		std::map<std::string, BufferedImage*> mImageMap;
 

--- a/src/RenderManagerGL2D.h
+++ b/src/RenderManagerGL2D.h
@@ -50,16 +50,11 @@ class RenderManagerGL2D : public RenderManager
 
 		void init(int xResolution, int yResolution, bool fullscreen) override;
 		void deinit() override;
-		void draw() override;
 		void refresh() override;
 
 		bool setBackground(const std::string& filename) override;
 		void setBlobColor(int player, Color color) override;
 		void showShadow(bool shadow) override;
-
-		void setBall(const Vector2& position, float rotation) override;
-		void setBlob(int player, const Vector2& position,
-				float animationState) override;
 
 		void drawText(const std::string& text, Vector2 position, unsigned int flags = TF_NORMAL) override;
 		void drawImage(const std::string& filename, Vector2 position, Vector2 size) override;
@@ -68,6 +63,7 @@ class RenderManagerGL2D : public RenderManager
 		void startDrawParticles() override;
 		void drawParticle(const Vector2& pos, int player) override;
 		void endDrawParticles() override;
+		void drawGame(const DuelMatchState& gameState) override;
 
 	private:
 		// Make sure this object is created before any opengl call
@@ -94,13 +90,6 @@ class RenderManagerGL2D : public RenderManager
 		GLuint mParticle;
 
 		std::list<Vector2> mLastBallStates;
-
-		Vector2 mBallPosition;
-		float mBallRotation;
-		Vector2 mLeftBlobPosition;
-		float mLeftBlobAnimationState;
-		Vector2 mRightBlobPosition;
-		float mRightBlobAnimationState;
 
 		bool mShowShadow;
 

--- a/src/RenderManagerSDL.h
+++ b/src/RenderManagerSDL.h
@@ -38,16 +38,11 @@ class RenderManagerSDL : public RenderManager
 
 		void init(int xResolution, int yResolution, bool fullscreen) override;
 		void deinit() override;
-		void draw() override;
 		void refresh() override;
 
 		bool setBackground(const std::string& filename) override;
 		void setBlobColor(int player, Color color) override;
 		void showShadow(bool shadow) override;
-
-		void setBall(const Vector2& position, float rotation) override;
-		void setBlob(int player, const Vector2& position,
-				float animationState) override;
 
 		void setMouseMarker(float position) override;
 
@@ -56,6 +51,7 @@ class RenderManagerSDL : public RenderManager
 		void drawOverlay(float opacity, Vector2 pos1, Vector2 pos2, Color col) override;
 		void drawBlob(const Vector2& pos, const Color& col) override;
 		void drawParticle(const Vector2& pos, int player) override;
+		void drawGame(const DuelMatchState& gameState) override;
 
 	private:
 		struct DynamicColoredTexture
@@ -95,13 +91,6 @@ class RenderManagerSDL : public RenderManager
 
 		SDL_Renderer* mRenderer = nullptr;
 
-		Vector2 mBallPosition;
-		float mBallRotation;
-		Vector2 mLeftBlobPosition;
-		float mLeftBlobAnimationState;
-		Vector2 mRightBlobPosition;
-		float mRightBlobAnimationState;
-
 		bool mShowShadow;
 
 		// Store color for caching
@@ -115,7 +104,7 @@ class RenderManagerSDL : public RenderManager
 		SDL_Surface* colorSurface(SDL_Surface *surface, Color color);
 
 		void drawTextImpl(const std::string& text, Vector2 position, unsigned int flags);
-		void colorizeBlobs(int player);
+		void colorizeBlobs(int player, int frame);
 
 #if !BLOBBY_FEATURE_HAS_BACKBUTTON
         SDL_Texture* mBackFlag;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,6 @@ void setupPHYSFS()
 
 			if (!scontroller.doFramedrop())
 			{
-				rmanager->draw();
 				IMGUI::getSingleton().end(*rmanager);
 				rmanager->getBlood().step(*rmanager);
 				rmanager->refresh();

--- a/src/runtest.cpp
+++ b/src/runtest.cpp
@@ -247,7 +247,6 @@ int main(int argc, char* argv[])
 
 			if (!scontroller.doFramedrop())
 			{
-				rmanager->draw();
 				IMGUI::getSingleton().end(*rmanager);
 				rmanager->getBlood().step(*rmanager);
 				rmanager->refresh();

--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -39,20 +39,12 @@ GameState::GameState(DuelMatch* match) : mMatch(match), mSaveReplay(false)
 
 GameState::~GameState()
 {
-	// disable game drawing
-	RenderManager::getSingleton().drawGame(false);
 }
 
 void GameState::presentGame()
 {
-	// enable game drawing
-	RenderManager::getSingleton().drawGame(true);
-
 	RenderManager& rmanager = RenderManager::getSingleton();
 	SoundManager& smanager = SoundManager::getSingleton();
-
-	rmanager.setBlob(LEFT_PLAYER, mMatch->getBlobPosition(LEFT_PLAYER), mMatch->getBlobState(LEFT_PLAYER));
-	rmanager.setBlob(RIGHT_PLAYER, mMatch->getBlobPosition(RIGHT_PLAYER),	mMatch->getBlobState(RIGHT_PLAYER));
 
 	if(mMatch->getPlayer(LEFT_PLAYER).getOscillating())
 	{
@@ -72,8 +64,6 @@ void GameState::presentGame()
 		rmanager.setBlobColor(RIGHT_PLAYER, mMatch->getPlayer(RIGHT_PLAYER).getStaticColor());
 	}
 
-	rmanager.setBall(mMatch->getBallPosition(), mMatch->getBallRotation());
-
 	auto events = mMatch->getEvents( );
 	for(const auto& e : events )
 	{
@@ -92,6 +82,8 @@ void GameState::presentGame()
 
 void GameState::presentGameUI()
 {
+	RenderManager::getSingleton().drawGame(mMatch->getState());
+
 	auto& imgui = IMGUI::getSingleton();
 
 	// Scores


### PR DESCRIPTION
Instead of storing the game state directly in the renderer, we now provide a `drawGame` function that gets the state passed in as a parameter.