### PR TITLE
run cmake tests on ubuntu 20

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CMAKE_VERSION: 3.3.0
     steps:


### PR DESCRIPTION
some library (`libidn.so.11`) that cmake 3.3 requires seems to be missing in ubuntu 22, so we set the runner to usu ubuntu 20