### PR TITLE
structure path handling ( #15 )

### DIFF
--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -26,6 +26,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <iostream> /// \todo remove this? currently needed for that probeDir error messages
 #include <utility>
 
+
+#include <boost/algorithm/string/predicate.hpp>
+
 #if (defined __ANDROID__)
 #include <SDL.h>
 #endif
@@ -174,6 +177,28 @@ void FileSystem::probeDir(const std::string& dirname)
 	}
 }
 
+std::string FileSystem::join(const std::string& first, const std::string& second)
+{
+	const std::string& separator = getDirSeparator();
+	
+	bool firstEndsWithSeparator = boost::algorithm::ends_with(first, separator);
+	bool secondStartsWithSeparator = boost::algorithm::starts_with(second, separator);
+
+	// remove one unnecessary separator
+	if (firstEndsWithSeparator && secondStartsWithSeparator)
+	{
+		return first.substr(0, first.length() - separator.length()) + second;
+	}
+	
+	// no need to add or remove any separator
+	if (firstEndsWithSeparator || secondStartsWithSeparator)
+	{
+		return first + second;
+	}
+
+	// add missing separator
+	return first + separator + second;
+}
 
 // exception implementations
 

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -145,6 +145,11 @@ std::string FileSystem::getUserDir()
 	return PHYSFS_getUserDir();
 }
 
+std::string FileSystem::getPrefDir()
+{
+	return PHYSFS_getPrefDir("org.dk", "blobby");
+}
+
 void FileSystem::probeDir(const std::string& dirname)
 {
 	if ( !isDirectory(dirname) )

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -140,9 +140,9 @@ std::string FileSystem::getDirSeparator()
 	return PHYSFS_getDirSeparator();
 }
 
-std::string FileSystem::getUserDir()
+std::string FileSystem::getBaseDir()
 {
-	return PHYSFS_getUserDir();
+	return PHYSFS_getBaseDir();
 }
 
 std::string FileSystem::getPrefDir()

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -75,13 +75,12 @@ class FileSystem : public ObjectCounter<FileSystem>
 		/// do. also, its uses should be looked at again.
 		void probeDir(const std::string& dir);
 
-		/// \todo ideally, this method would never be needed by client code!!
+		/// \brief Get path seperator
 		std::string getDirSeparator();
 
-		/// \todo ideally, this method would never be needed by client code!!
-		std::string getUserDir();
+		/// \brief Get the path where the application resides
+		std::string getBaseDir();
 
-		/// \brief Get the user-and-app-specific path where files can be written.
-		/// \todo ideally, this method would never be needed by client code!!
+		/// \brief Get the user-and-app-specific path where files can be written
 		std::string getPrefDir();
 };

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -80,4 +80,8 @@ class FileSystem : public ObjectCounter<FileSystem>
 
 		/// \todo ideally, this method would never be needed by client code!!
 		std::string getUserDir();
+
+		/// \brief Get the user-and-app-specific path where files can be written.
+		/// \todo ideally, this method would never be needed by client code!!
+		std::string getPrefDir();
 };

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -83,4 +83,7 @@ class FileSystem : public ObjectCounter<FileSystem>
 
 		/// \brief Get the user-and-app-specific path where files can be written
 		std::string getPrefDir();
+
+		/// \brief Concatenates two path components with exactly one directory separator
+		std::string join(const std::string& first, const std::string& second);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,12 +100,12 @@ void setupPHYSFS()
 	#if BLOBBY_ON_DESKTOP
 		std::string prefDir = fs.getPrefDir();
 		fs.setWriteDir(prefDir);
-		fs.probeDir(prefDir + "replays");
-		fs.probeDir(prefDir + "gfx");
-		fs.probeDir(prefDir + "sounds");
-		fs.probeDir(prefDir + "scripts");
-		fs.probeDir(prefDir + "backgrounds");
-		fs.probeDir(prefDir + "rules");
+		fs.probeDir("replays");
+		fs.probeDir("gfx");
+		fs.probeDir("sounds");
+		fs.probeDir("scripts");
+		fs.probeDir("backgrounds");
+		fs.probeDir("rules");
 	#endif
 
 	/*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,7 @@ void setupPHYSFS()
 	// Game should be playable out of the source package on all
 	// relevant platforms.
 	#if BLOBBY_ON_DESKTOP
-		std::string baseSearchPath("data" + fs.getDirSeparator());
+		std::string baseSearchPath("data");
 	#else
 		std::string baseSearchPath(fs.getBaseDir());
 	#endif
@@ -101,11 +101,11 @@ void setupPHYSFS()
 	set read dir (local files next to application)
 	*/
 	fs.addToSearchPath(baseSearchPath);
-	fs.addToSearchPath(baseSearchPath + "gfx.zip");
-	fs.addToSearchPath(baseSearchPath + "sounds.zip");
-	fs.addToSearchPath(baseSearchPath + "scripts.zip");
-	fs.addToSearchPath(baseSearchPath + "backgrounds.zip");
-	fs.addToSearchPath(baseSearchPath + "rules.zip");
+	fs.addToSearchPath(fs.join(baseSearchPath, "gfx.zip"));
+	fs.addToSearchPath(fs.join(baseSearchPath, "sounds.zip"));
+	fs.addToSearchPath(fs.join(baseSearchPath, "scripts.zip"));
+	fs.addToSearchPath(fs.join(baseSearchPath, "backgrounds.zip"));
+	fs.addToSearchPath(fs.join(baseSearchPath, "rules.zip"));
 
 	/*
 	set read dir (unix-like when installed)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ void setupPHYSFS()
 	#if BLOBBY_ON_DESKTOP
 		std::string baseSearchPath("data" + separator);
 	#elif (defined __ANDROID__)
+		/// TODO: This seems to be wrong
 		std::string baseSearchPath(SDL_AndroidGetExternalStoragePath() + separator);
 	#elif (defined __APPLE__) || (defined __SWITCH__)
 		// iOS
@@ -95,11 +96,21 @@ void setupPHYSFS()
 	#endif
 
 	/*
-	set write dir (desktop)
+	set write dir
 	*/
-	#if BLOBBY_ON_DESKTOP
-		std::string prefDir = fs.getPrefDir();
-		fs.setWriteDir(prefDir);
+	#if BLOBBY_ON_DESKTOP || (defined __APPLE__ && TARGET_OS_IPHONE)
+		std::string writeDir = fs.getPrefDir();
+		fs.setWriteDir(writeDir);
+		fs.probeDir("replays");
+		fs.probeDir("gfx");
+		fs.probeDir("sounds");
+		fs.probeDir("scripts");
+		fs.probeDir("backgrounds");
+		fs.probeDir("rules");
+	#elif (defined __ANDROID__)
+		/// TODO: Check if we can use PrefDir on Android, too.
+		std::string writeDir(SDL_AndroidGetExternalStoragePath() + separator);
+		fs.setWriteDir(writeDir);
 		fs.probeDir("replays");
 		fs.probeDir("gfx");
 		fs.probeDir("sounds");
@@ -131,23 +142,10 @@ void setupPHYSFS()
 	#endif
 
 	/// \todo the following lines must be refactored!!!!
-	#if (!defined __ANDROID__) && (!BLOBBY_ON_DESKTOP)
+	#if (!defined __ANDROID__) && !(defined __APPLE__ && TARGET_OS_IPHONE) && (!BLOBBY_ON_DESKTOP)
 		// Create a search path in the home directory and ensure that
 		// all paths exist and are actually directories
-		#if (defined __APPLE__) || (defined __SWITCH__)
-			#if TARGET_OS_SIMULATOR
-				// The simulator doesn't create documentsfolder anymore, we create it if necessary
-				fs.setWriteDir(baseSearchPath + "../");
-				fs.probeDir("Documents");
-			#endif
-			#if TARGET_OS_IPHONE
-				std::string userdir = baseSearchPath + "../Documents/";
-			#else
-				std::string userdir = fs.getUserDir();
-			#endif
-		#else
-			std::string userdir = fs.getUserDir();
-		#endif
+		std::string userdir = fs.getUserDir();
 		std::string userAppend = ".blobby";
 		std::string homedir = userdir + userAppend;
 		/// \todo please review this code and determine if we really need to add userdir to search path
@@ -164,15 +162,6 @@ void setupPHYSFS()
 		fs.removeFromSearchPath(userdir);
 		// here we set the write dir anew!
 		fs.setWriteDir(homedir);
-	#endif
-	#if (defined __ANDROID__)
-		fs.setWriteDir(baseSearchPath);
-		fs.probeDir("replays");
-		fs.probeDir("gfx");
-		fs.probeDir("sounds");
-		fs.probeDir("scripts");
-		fs.probeDir("backgrounds");
-		fs.probeDir("rules");
 	#endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,6 +94,23 @@ void setupPHYSFS()
 		std::string baseSearchPath(PHYSFS_getBaseDir());
 	#endif
 
+	/*
+	set write dir (desktop)
+	*/
+	#if BLOBBY_ON_DESKTOP
+		std::string prefDir = fs.getPrefDir();
+		fs.setWriteDir(prefDir);
+		fs.probeDir(prefDir + "replays");
+		fs.probeDir(prefDir + "gfx");
+		fs.probeDir(prefDir + "sounds");
+		fs.probeDir(prefDir + "scripts");
+		fs.probeDir(prefDir + "backgrounds");
+		fs.probeDir(prefDir + "rules");
+	#endif
+
+	/*
+	set read dir (local files next to application)
+	*/
 	fs.addToSearchPath(baseSearchPath);
 	fs.addToSearchPath(baseSearchPath + "gfx.zip");
 	fs.addToSearchPath(baseSearchPath + "sounds.zip");
@@ -101,75 +118,61 @@ void setupPHYSFS()
 	fs.addToSearchPath(baseSearchPath + "backgrounds.zip");
 	fs.addToSearchPath(baseSearchPath + "rules.zip");
 
-	#if defined(WIN32)
-		// Just write in installation directory
-		fs.setWriteDir("data");
-	#else
-		#if (!defined __ANDROID__)
-			// Create a search path in the home directory and ensure that
-			// all paths exist and are actually directories
-			#if (defined __APPLE__) || (defined __SWITCH__)
-				#if TARGET_OS_SIMULATOR
-					// The simulator doesn't create documentsfolder anymore, we create it if necessary
-					fs.setWriteDir(baseSearchPath + "../");
-					fs.probeDir("Documents");
-				#endif
-				#if TARGET_OS_IPHONE
-					std::string userdir = baseSearchPath + "../Documents/";
-				#else
-					std::string userdir = fs.getUserDir();
-				#endif
-			#else
-				// Linux
-				std::string userdir = fs.getUserDir();
+	/*
+	set read dir (unix-like when installed)
+	*/
+	#if BLOBBY_ON_DESKTOP && (!defined WIN32)
+		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby");
+		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/gfx.zip");
+		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/sounds.zip");
+		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/scripts.zip");
+		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/backgrounds.zip");
+		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/rules.zip");
+	#endif
 
-				// handle the case when it is installed
-				fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby");
-				fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/gfx.zip");
-				fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/sounds.zip");
-				fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/scripts.zip");
-				fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/backgrounds.zip");
-				fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/rules.zip");
+	/// \todo the following lines must be refactored!!!!
+	#if (!defined __ANDROID__) && (!BLOBBY_ON_DESKTOP)
+		// Create a search path in the home directory and ensure that
+		// all paths exist and are actually directories
+		#if (defined __APPLE__) || (defined __SWITCH__)
+			#if TARGET_OS_SIMULATOR
+				// The simulator doesn't create documentsfolder anymore, we create it if necessary
+				fs.setWriteDir(baseSearchPath + "../");
+				fs.probeDir("Documents");
 			#endif
-			std::string userAppend = ".blobby";
-			std::string homedir = userdir + userAppend;
-			/// \todo please review this code and determine if we really need to add userdir to search path
-			/// only to remove it later
-			fs.setWriteDir(userdir);
-			fs.probeDir(userAppend);
-			/// \todo why do we need separator here?
-			fs.probeDir(userAppend + separator + "replays");
-			fs.probeDir(userAppend + separator + "gfx");
-			fs.probeDir(userAppend + separator + "sounds");
-			fs.probeDir(userAppend + separator + "scripts");
-			fs.probeDir(userAppend + separator + "backgrounds");
-			fs.probeDir(userAppend + separator + "rules");
-			fs.removeFromSearchPath(userdir);
-			// here we set the write dir anew!
-			fs.setWriteDir(homedir);
-			#if defined(GAMEDATADIR)
-			{
-				// A global installation path makes only sense on non-Windows
-				// platforms
-				std::string basedir = GAMEDATADIR;
-				fs.addToSearchPath(basedir);
-				fs.addToSearchPath(basedir + separator + "gfx.zip");
-				fs.addToSearchPath(basedir + separator + "sounds.zip");
-				fs.addToSearchPath(basedir + separator + "scripts.zip");
-				fs.addToSearchPath(basedir + separator + "backgrounds.zip");
-				fs.addToSearchPath(basedir + separator + "rules.zip");
-			}
+			#if TARGET_OS_IPHONE
+				std::string userdir = baseSearchPath + "../Documents/";
+			#else
+				std::string userdir = fs.getUserDir();
 			#endif
 		#else
-			fs.setWriteDir(baseSearchPath);
-			fs.probeDir("replays");
-			fs.probeDir("gfx");
-			fs.probeDir("sounds");
-			fs.probeDir("scripts");
-			fs.probeDir("backgrounds");
-			fs.probeDir("rules");
+			std::string userdir = fs.getUserDir();
 		#endif
-
+		std::string userAppend = ".blobby";
+		std::string homedir = userdir + userAppend;
+		/// \todo please review this code and determine if we really need to add userdir to search path
+		/// only to remove it later
+		fs.setWriteDir(userdir);
+		fs.probeDir(userAppend);
+		/// \todo why do we need separator here?
+		fs.probeDir(userAppend + separator + "replays");
+		fs.probeDir(userAppend + separator + "gfx");
+		fs.probeDir(userAppend + separator + "sounds");
+		fs.probeDir(userAppend + separator + "scripts");
+		fs.probeDir(userAppend + separator + "backgrounds");
+		fs.probeDir(userAppend + separator + "rules");
+		fs.removeFromSearchPath(userdir);
+		// here we set the write dir anew!
+		fs.setWriteDir(homedir);
+	#endif
+	#if (defined __ANDROID__)
+		fs.setWriteDir(baseSearchPath);
+		fs.probeDir("replays");
+		fs.probeDir("gfx");
+		fs.probeDir("sounds");
+		fs.probeDir("scripts");
+		fs.probeDir("backgrounds");
+		fs.probeDir("rules");
 	#endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ void setupPHYSFS()
 	/*
 	set write dir
 	*/
-	#if BLOBBY_ON_DESKTOP || (defined __APPLE__ && TARGET_OS_IPHONE)
+	#if !(defined __ANDROID__)
 		std::string writeDir = fs.getPrefDir();
 		fs.setWriteDir(writeDir);
 		fs.probeDir("replays");
@@ -107,7 +107,7 @@ void setupPHYSFS()
 		fs.probeDir("scripts");
 		fs.probeDir("backgrounds");
 		fs.probeDir("rules");
-	#elif (defined __ANDROID__)
+	#else
 		/// TODO: Check if we can use PrefDir on Android, too.
 		std::string writeDir(SDL_AndroidGetExternalStoragePath() + separator);
 		fs.setWriteDir(writeDir);
@@ -139,29 +139,6 @@ void setupPHYSFS()
 		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/scripts.zip");
 		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/backgrounds.zip");
 		fs.addToSearchPath(BLOBBY_INSTALL_PREFIX  "/share/blobby/rules.zip");
-	#endif
-
-	/// \todo the following lines must be refactored!!!!
-	#if (!defined __ANDROID__) && !(defined __APPLE__ && TARGET_OS_IPHONE) && (!BLOBBY_ON_DESKTOP)
-		// Create a search path in the home directory and ensure that
-		// all paths exist and are actually directories
-		std::string userdir = fs.getUserDir();
-		std::string userAppend = ".blobby";
-		std::string homedir = userdir + userAppend;
-		/// \todo please review this code and determine if we really need to add userdir to search path
-		/// only to remove it later
-		fs.setWriteDir(userdir);
-		fs.probeDir(userAppend);
-		/// \todo why do we need separator here?
-		fs.probeDir(userAppend + separator + "replays");
-		fs.probeDir(userAppend + separator + "gfx");
-		fs.probeDir(userAppend + separator + "sounds");
-		fs.probeDir(userAppend + separator + "scripts");
-		fs.probeDir(userAppend + separator + "backgrounds");
-		fs.probeDir(userAppend + separator + "rules");
-		fs.removeFromSearchPath(userdir);
-		// here we set the write dir anew!
-		fs.setWriteDir(homedir);
 	#endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,12 +30,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "Global.h"
 
-#ifdef __APPLE__
-	#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-		#include <physfs.h>
-	#endif
-#endif
-
 #if BLOBBY_ON_DESKTOP
 	#ifndef WIN32
 		#include "config.h"
@@ -82,42 +76,26 @@ void deinit()
 void setupPHYSFS()
 {
 	FileSystem& fs = FileSystem::getSingleton();
-	const std::string separator = fs.getDirSeparator();
+	
 	// Game should be playable out of the source package on all
 	// relevant platforms.
 	#if BLOBBY_ON_DESKTOP
-		std::string baseSearchPath("data" + separator);
-	#elif (defined __ANDROID__)
-		/// TODO: This seems to be wrong
-		std::string baseSearchPath(SDL_AndroidGetExternalStoragePath() + separator);
-	#elif (defined __APPLE__) || (defined __SWITCH__)
-		// iOS
-		std::string baseSearchPath(PHYSFS_getBaseDir());
+		std::string baseSearchPath("data" + fs.getDirSeparator());
+	#else
+		std::string baseSearchPath(fs.getBaseDir());
 	#endif
 
 	/*
 	set write dir
 	*/
-	#if !(defined __ANDROID__)
-		std::string writeDir = fs.getPrefDir();
-		fs.setWriteDir(writeDir);
-		fs.probeDir("replays");
-		fs.probeDir("gfx");
-		fs.probeDir("sounds");
-		fs.probeDir("scripts");
-		fs.probeDir("backgrounds");
-		fs.probeDir("rules");
-	#else
-		/// TODO: Check if we can use PrefDir on Android, too.
-		std::string writeDir(SDL_AndroidGetExternalStoragePath() + separator);
-		fs.setWriteDir(writeDir);
-		fs.probeDir("replays");
-		fs.probeDir("gfx");
-		fs.probeDir("sounds");
-		fs.probeDir("scripts");
-		fs.probeDir("backgrounds");
-		fs.probeDir("rules");
-	#endif
+	std::string writeDir = fs.getPrefDir();
+	fs.setWriteDir(writeDir);
+	fs.probeDir("replays");
+	fs.probeDir("gfx");
+	fs.probeDir("sounds");
+	fs.probeDir("scripts");
+	fs.probeDir("backgrounds");
+	fs.probeDir("rules");
 
 	/*
 	set read dir (local files next to application)

--- a/src/runtest.cpp
+++ b/src/runtest.cpp
@@ -73,7 +73,7 @@ void setupPHYSFS()
 	// Create a search path in the home directory and ensure that
 	// all paths exist and are actually directories
 	// Linux
-	std::string userdir = fs.getUserDir();
+	std::string userdir = fs.getPrefDir();
 
 	std::string userAppend = ".blobby";
 	std::string homedir = userdir + userAppend;

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 	FileSystem fs3("__SPAM__");
 }
 
-// the functions deleteFile, exists, isDirectory, addToSearchPath, removeFromSearchPath, setWriteDir and getUserDir
+// the functions deleteFile, exists, isDirectory, addToSearchPath, removeFromSearchPath, setWriteDir and getBaseDir
 // currently just wrap PHYSFS functions, so they actually don't do anything. Thus, these functions are not
 // tested here. Once we have a defined error reporting policy etc, tests will be added.
 


### PR DESCRIPTION
- use PrefDir of physfs as write folder (on windows too!)
- support XDG directory specificiation
- remove deprecated GAMEDATADIR
- sort pathes and add comments to make clear the idea behind all that