### PR TITLE
Fix replay crash

### DIFF
--- a/src/runtest.cpp
+++ b/src/runtest.cpp
@@ -237,8 +237,8 @@ int main(int argc, char* argv[])
 		add_key_event(SDLK_DOWN);
 		add_key_event(SDLK_RETURN);
 
-		// let the replay run: effectively NOPS
-		add_key_event(SDLK_LEFT, 200);
+		// let the replay run, but shorter than the game before
+		add_key_event(SDLK_LEFT, 100);
 
 		// end replay and game
 		add_key_event(SDLK_ESCAPE);

--- a/src/runtest.cpp
+++ b/src/runtest.cpp
@@ -213,9 +213,36 @@ int main(int argc, char* argv[])
 		// let the bots play: effectively NOPS
 		add_key_event(SDLK_LEFT, 200);
 
+		// save the replay and back to main menu
 		add_key_event(SDLK_ESCAPE);
 		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
 		add_key_event(SDLK_RETURN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_RETURN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_RETURN);
+
+		// go to replay
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_RETURN);
+
+		// start replay
+		add_key_event(SDLK_DOWN);
+		add_key_event(SDLK_RETURN);
+
+		// let the replay run: effectively NOPS
+		add_key_event(SDLK_LEFT, 200);
+
+		// end replay and game
+		add_key_event(SDLK_ESCAPE);
+		add_key_event(SDLK_ESCAPE);
 		add_key_event(SDLK_ESCAPE);
 
 		int step = 0;

--- a/src/state/ReplayState.cpp
+++ b/src/state/ReplayState.cpp
@@ -48,6 +48,7 @@ ReplayState::ReplayState()
 
 void ReplayState::init()
 {
+	playSound(SoundManager::WHISTLE, ROUND_START_SOUND_VOLUME);
 }
 
 
@@ -64,8 +65,6 @@ void ReplayState::loadReplay(const std::string& file)
 		rulesFile.write(mReplayPlayer->getRules());
 		rulesFile.close();
 		mMatch.reset(new DuelMatch(false, TEMP_RULES_NAME));
-
-		playSound(SoundManager::WHISTLE, ROUND_START_SOUND_VOLUME);
 
 		mMatch->setPlayers(PlayerIdentity{mReplayPlayer->getPlayerName(LEFT_PLAYER)},
 		                   PlayerIdentity{mReplayPlayer->getPlayerName(RIGHT_PLAYER)});

--- a/src/state/State.h
+++ b/src/state/State.h
@@ -72,7 +72,7 @@ private:
 	friend class BlobbyApp;
 	void setApp(BlobbyApp* app);
 
-	BlobbyApp* m_App;
+	BlobbyApp* m_App = nullptr;
 
 };
 


### PR DESCRIPTION
Extends the CI to try showing a replay, which catches the replay problem as shown [here](https://github.com/danielknobe/blobbyvolley2/actions/runs/3802995809/jobs/6469003570). 
Fixes #77 by delaying the sound until the state is actually being initialized.