### PR TITLE
Enabled blobby-server on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,9 +127,12 @@ endif (UNIX)
 
 if (WIN32)
 	set_target_properties(blobby PROPERTIES LINK_FLAGS "-mwindows") # disable the console window
+	set_target_properties(blobby-server PROPERTIES LINK_FLAGS "-mconsole") # enable the console window
 	install(TARGETS blobby blobby-server DESTINATION .)
 elseif (UNIX AND (NOT ${CMAKE_SYSTEM_NAME} STREQUAL Android))
 	install(TARGETS blobby blobby-server DESTINATION bin)
+elseif (UNIX AND (${CMAKE_SYSTEM_NAME} STREQUAL Android))
+	install(TARGETS blobby DESTINATION bin)
 elseif (SWITCH)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blobby.nro DESTINATION .)
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,9 +116,11 @@ else (SWITCH)
 endif (SWITCH)
 
 
-if (UNIX)
+if (UNIX OR WIN32)
 	add_executable(blobby-server ${blobby-server_SRC})
 	target_link_libraries(blobby-server ${BLOBBY_COMMON_LIBS})
+endif (UNIX OR WIN32)	
+if (UNIX)
 	add_executable(blobby-runtest EXCLUDE_FROM_ALL runtest.cpp ${blobby_SRC})
 	target_link_libraries(blobby-runtest ${BLOBBY_COMMON_LIBS} ${OPENGL_LIBRARIES})
 endif (UNIX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,10 +116,10 @@ else (SWITCH)
 endif (SWITCH)
 
 
-if (UNIX OR WIN32)
+if (UNIX AND (NOT ${CMAKE_SYSTEM_NAME} STREQUAL Android) OR WIN32)
 	add_executable(blobby-server ${blobby-server_SRC})
 	target_link_libraries(blobby-server ${BLOBBY_COMMON_LIBS})
-endif (UNIX OR WIN32)	
+endif ()
 if (UNIX)
 	add_executable(blobby-runtest EXCLUDE_FROM_ALL runtest.cpp ${blobby_SRC})
 	target_link_libraries(blobby-runtest ${BLOBBY_COMMON_LIBS} ${OPENGL_LIBRARIES})
@@ -127,8 +127,8 @@ endif (UNIX)
 
 if (WIN32)
 	set_target_properties(blobby PROPERTIES LINK_FLAGS "-mwindows") # disable the console window
-	install(TARGETS blobby DESTINATION .)
-elseif (UNIX)
+	install(TARGETS blobby blobby-server DESTINATION .)
+elseif (UNIX AND (NOT ${CMAKE_SYSTEM_NAME} STREQUAL Android))
 	install(TARGETS blobby blobby-server DESTINATION bin)
 elseif (SWITCH)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blobby.nro DESTINATION .)

--- a/src/server/servermain.cpp
+++ b/src/server/servermain.cpp
@@ -34,6 +34,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
+#include <SDL.h>
+
 #include "DedicatedServer.h"
 #include "SpeedController.h"
 #include "FileSystem.h"
@@ -59,7 +61,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* implementation */
 
 #ifdef WIN32
-#undef main
 
 // function for logging to replacing syslog
 void syslog(int pri, const char* format, ...);
@@ -190,6 +191,8 @@ int main(int argc, char** argv)
 	#ifndef WIN32
 	closelog();
 	#endif
+
+	return 0;
 }
 
 // -----------------------------------------------------------------------------------------
@@ -315,7 +318,6 @@ void setup_physfs(char* argv0)
 
 
 #ifdef WIN32
-#undef main
 
 void syslog(int pri, const char* format, ...)
 {


### PR DESCRIPTION
Enabled blobby-server on Windows. Solves #74 .

I would have liked to use the SpeedController from #48 . 
Unfortunately std::this_thread::sleep_for seems to be very imprecise under Windows (at least when building with MSYS2). 
This leads to very unstable frame rates with some stuttering.
I decided against an integration in the context of this PR.
The disadvantage is that we still have to include and link SDL for the server.