### PR TITLE
dedicated server: load game speed(s) correctly

### DIFF
--- a/src/server/servermain.cpp
+++ b/src/server/servermain.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
 		config.loadFile(g_config_file);
 		maxClients = config.getInteger("maximum_clients");
 		rulesFile  = config.getString("rules", DEFAULT_RULES_FILE);
-		gameSpeeds = config.getString("speed", gameSpeeds);
+		gameSpeeds = config.getString("speeds", gameSpeeds);
 
 		// bring that value into a sane range
 		if(maxClients <= 0 || maxClients > 150)


### PR DESCRIPTION
Fix for loading gamespeed(s) from config (bug introduced with 07b5847c7bb8b0cae39ca641c68cad4d3c712475).

This fixes second issue described in #79 .