### PR TITLE
fixed a reference to InputManager::getSingleton

### DIFF
--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -699,7 +699,7 @@ void InputOptionsState::step_impl()
 	imgui.doImage(GEN_ID, Vector2(400.0, 300.0), "background");
 	imgui.doOverlay(GEN_ID, Vector2(0.0, 0.0), Vector2(800.0, 600.0));
 
-	std::string lastActionKey = InputManager::getSingleton()->getLastActionKey();
+	std::string lastActionKey = getInputMgr().getLastActionKey();
 
 	// left player side:
 	handlePlayerInput(LEFT_PLAYER, mLeftJoystick);


### PR DESCRIPTION
found this while searching for remaining references to singletons. 
Without actually compiling for the switch, though, I guess it is a bit difficult to ensure that this was the only thing that got broken by the recent changes.