### PR TITLE
increase minimum cmake version to 3.7

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -13,7 +13,7 @@ jobs:
   Build:
     runs-on: ubuntu-20.04
     env:
-      CMAKE_VERSION: 3.3.0
+      CMAKE_VERSION: 3.7.0
     steps:
       - name: Setup Linux
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
 
-# Work around older versions of CMake not providing the ANDROID variable
-if(${CMAKE_VERSION} VERSION_LESS "3.7")
-	if (UNIX AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
-		set(ANDROID ON)
-	endif()
-endif()
-
 include(CPack)
 
 project(Blobby)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.7)
 
 # Work around older versions of CMake not providing the ANDROID variable
 if(${CMAKE_VERSION} VERSION_LESS "3.7")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ git clone https://github.com/danielknobe/blobbyvolley2.git
 
 ### Build under Linux
 Blobby Volley compiles with GCC 5 or newer, or Clang 10 or newer.
-Other compilers may work but are currently untested.
+Other compilers may work but are currently untested. The minimum supported
+CMake version is 3.7.
 
 1. Install dependencies:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,16 +91,12 @@ if (SWITCH)
 	find_library(NX nx)
 endif (SWITCH)
 
-include_directories(
-	${Boost_INCLUDE_DIR}
-)
-
 if (OPENGL_FOUND)
 	include_directories(${OPENGL_INCLUDE_DIR})
 	add_definitions(-DHAVE_LIBGL)
 endif (OPENGL_FOUND)
 
-set(BLOBBY_COMMON_LIBS lua::lua blobnet::blobnet tinyxml2::tinyxml2 PhysFS::PhysFS SDL2::SDL2main SDL2::SDL2)
+set(BLOBBY_COMMON_LIBS lua::lua blobnet::blobnet tinyxml2::tinyxml2 PhysFS::PhysFS SDL2::SDL2main SDL2::SDL2 Boost::boost)
 
 # other additional dependencies
 if (NOT WIN32)


### PR DESCRIPTION
with cmake 3.7, we can also switch to using an imported target for boost.