### PR TITLE
changed argument passing

### DIFF
--- a/src/replays/ReplayRecorder.cpp
+++ b/src/replays/ReplayRecorder.cpp
@@ -81,7 +81,7 @@ void writeAttribute(tinyxml2::XMLPrinter& printer, const char* name, const T& va
 	printer.CloseElement();
 }
 
-void ReplayRecorder::save( const std::shared_ptr<FileWrite>& file) const
+void ReplayRecorder::save(FileWrite& file) const
 {
 	tinyxml2::XMLPrinter printer;
 	printer.PushHeader(false, true);
@@ -131,43 +131,43 @@ void ReplayRecorder::save( const std::shared_ptr<FileWrite>& file) const
 	printer.CloseElement();
 
 	printer.CloseElement();  // </replay>
-	file->write(printer.CStr(), printer.CStrSize() - 1); // do not save the terminating \0 character
+	file.write(printer.CStr(), printer.CStrSize() - 1); // do not save the terminating \0 character
 }
 
-void ReplayRecorder::send(const std::shared_ptr<GenericOut>& target) const
+void ReplayRecorder::send(GenericOut& target) const
 {
-	target->string(mPlayerNames[LEFT_PLAYER]);
-	target->string(mPlayerNames[RIGHT_PLAYER]);
+	target.string(mPlayerNames[LEFT_PLAYER]);
+	target.string(mPlayerNames[RIGHT_PLAYER]);
 
-	target->generic<Color> (mPlayerColors[LEFT_PLAYER]);
-	target->generic<Color> (mPlayerColors[RIGHT_PLAYER]);
+	target.generic<Color> (mPlayerColors[LEFT_PLAYER]);
+	target.generic<Color> (mPlayerColors[RIGHT_PLAYER]);
 
-	target->uint32( mGameSpeed );
-	target->uint32( mEndScore[LEFT_PLAYER] );
-	target->uint32( mEndScore[RIGHT_PLAYER] );
+	target.uint32( mGameSpeed );
+	target.uint32( mEndScore[LEFT_PLAYER] );
+	target.uint32( mEndScore[RIGHT_PLAYER] );
 
-	target->string(mGameRules);
+	target.string(mGameRules);
 
-	target->generic<std::vector<unsigned char> >(mSaveData);
-	target->generic<std::vector<ReplaySavePoint> > (mSavePoints);
+	target.generic<std::vector<unsigned char> >(mSaveData);
+	target.generic<std::vector<ReplaySavePoint> > (mSavePoints);
 }
 
-void ReplayRecorder::receive(const std::shared_ptr<GenericIn>& source)
+void ReplayRecorder::receive(GenericIn& source)
 {
-	source->string(mPlayerNames[LEFT_PLAYER]);
-	source->string(mPlayerNames[RIGHT_PLAYER]);
+	source.string(mPlayerNames[LEFT_PLAYER]);
+	source.string(mPlayerNames[RIGHT_PLAYER]);
 
-	source->generic<Color> (mPlayerColors[LEFT_PLAYER]);
-	source->generic<Color> (mPlayerColors[RIGHT_PLAYER]);
+	source.generic<Color> (mPlayerColors[LEFT_PLAYER]);
+	source.generic<Color> (mPlayerColors[RIGHT_PLAYER]);
 
-	source->uint32( mGameSpeed );
-	source->uint32( mEndScore[LEFT_PLAYER] );
-	source->uint32( mEndScore[RIGHT_PLAYER] );
+	source.uint32( mGameSpeed );
+	source.uint32( mEndScore[LEFT_PLAYER] );
+	source.uint32( mEndScore[RIGHT_PLAYER] );
 
-	source->string(mGameRules);
+	source.string(mGameRules);
 
-	source->generic<std::vector<unsigned char> >(mSaveData);
-	source->generic<std::vector<ReplaySavePoint> > (mSavePoints);
+	source.generic<std::vector<unsigned char> >(mSaveData);
+	source.generic<std::vector<ReplaySavePoint> > (mSavePoints);
 }
 
 void ReplayRecorder::record(const DuelMatchState& state)

--- a/src/replays/ReplayRecorder.h
+++ b/src/replays/ReplayRecorder.h
@@ -66,10 +66,10 @@ class ReplayRecorder : public ObjectCounter<ReplayRecorder>
 		ReplayRecorder();
 		~ReplayRecorder();
 
-		void save(const std::shared_ptr<FileWrite>& target) const;
+		void save(FileWrite& target) const;
 
-		void send(const std::shared_ptr<GenericOut>& stream) const;
-		void receive(const std::shared_ptr<GenericIn>&stream);
+		void send(GenericOut& stream) const;
+		void receive(GenericIn& stream);
 
 		// recording functions
 		void record(const DuelMatchState& input);

--- a/src/server/NetworkGame.cpp
+++ b/src/server/NetworkGame.cpp
@@ -261,7 +261,7 @@ void NetworkGame::processPacket( const packet_ptr& packet )
 			RakNet::BitStream stream;
 			stream.Write((unsigned char)ID_REPLAY);
 			std::shared_ptr<GenericOut> out = createGenericWriter( &stream );
-			mRecorder->send( out );
+			mRecorder->send( *out );
 			assert( stream.GetData()[0] == ID_REPLAY );
 
 			mServer.Send(&stream, LOW_PRIORITY, RELIABLE_ORDERED, 0, packet->playerId, false);

--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -206,10 +206,9 @@ void GameState::saveReplay(ReplayRecorder& recorder)
 		{
 			std::string repFileName = std::string("replays/") + mFilename + std::string(".bvr");
 
-			std::shared_ptr<FileWrite> savetarget = std::make_shared<FileWrite>(repFileName);
+			FileWrite savetarget(repFileName);
 			/// \todo add a check whether we overwrite a file
 			recorder.save(savetarget);
-			savetarget->close();
 			mSaveReplay = false;
 		}
 	}

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -318,7 +318,7 @@ void NetworkGameState::step_impl()
 				// read stream into a dummy replay recorder
 				std::shared_ptr<GenericIn> reader = createGenericReader( &stream );
 				ReplayRecorder dummyRec;
-				dummyRec.receive( reader );
+				dummyRec.receive( *reader );
 				// and save that
 				saveReplay(dummyRec);
 


### PR DESCRIPTION
we were passing arguments as `std::shared_ptr`, even though we were only using the objects for the duration of the function call.
This was misleading, as it indicates a transfer of ownership, and also locked in the call sites to use `std::shared_ptr`. 
Now these arguments are passed as references.