### PR TITLE
disentangle InputSource and DuelMatch

### DIFF
--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -63,9 +63,6 @@ void DuelMatch::setInputSources(std::shared_ptr<InputSource> left_input, std::sh
 
 	if(right_input)
 		mInputSources[RIGHT_PLAYER] = std::move(right_input);
-
-	mInputSources[LEFT_PLAYER]->setMatch(this);
-	mInputSources[RIGHT_PLAYER]->setMatch(this);
 }
 
 void DuelMatch::reset()
@@ -90,8 +87,8 @@ void DuelMatch::step()
 	if(mPaused)
 		return;
 
-	mTransformedInput[LEFT_PLAYER] = mInputSources[LEFT_PLAYER]->updateInput();
-	mTransformedInput[RIGHT_PLAYER] = mInputSources[RIGHT_PLAYER]->updateInput();
+	mTransformedInput[LEFT_PLAYER] = mInputSources[LEFT_PLAYER]->updateInput().toPlayerInput(this);
+	mTransformedInput[RIGHT_PLAYER] = mInputSources[RIGHT_PLAYER]->updateInput().toPlayerInput(this);
 
 	if(!mRemote)
 	{

--- a/src/InputSource.cpp
+++ b/src/InputSource.cpp
@@ -28,21 +28,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* InputSource */
 
-InputSource::InputSource() : mInput(), mMatch(nullptr)
+InputSource::InputSource() : mInput()
 {
 }
 
 InputSource::~InputSource() = default;
 
-PlayerInput InputSource::getInput() const
-{
-	return mInput.toPlayerInput( this->getMatch() );
-}
-
-PlayerInput InputSource::updateInput()
+PlayerInputAbs InputSource::updateInput()
 {
 	mInput = getNextInput();
-	return getInput();
+	return mInput;
 }
 
 void InputSource::setInput(PlayerInput ip)
@@ -65,15 +60,3 @@ PlayerInputAbs InputSource::getNextInput()
 {
 	return mInput;
 }
-
-const DuelMatch* InputSource::getMatch() const
-{
-	return mMatch;
-}
-
-void InputSource::setMatch(const DuelMatch* match)
-{
-	assert(mMatch == nullptr);
-	mMatch = match;
-}
-

--- a/src/InputSource.h
+++ b/src/InputSource.h
@@ -41,10 +41,7 @@ class InputSource : public ObjectCounter<InputSource>
 		virtual ~InputSource();
 
 		/// forces a recalculation of the input
-		PlayerInput updateInput();
-
-		/// gets the current input
-		PlayerInput getInput() const;
+		PlayerInputAbs updateInput();
 
 		/// get original input data
 		PlayerInputAbs getRealInput() const;
@@ -57,19 +54,10 @@ class InputSource : public ObjectCounter<InputSource>
 		/// of getInput
 		void setInput(PlayerInputAbs ip);
 
-		/// gets  match associated with this InputSource
-		const DuelMatch* getMatch() const;
-		/// sets match associated with this InputSource
-		/// should only be called once!
-		void setMatch(const DuelMatch* match);
-
 	private:
 		/// method that actually calculates the new input
 		virtual PlayerInputAbs getNextInput();
 
 		/// cached input
 		PlayerInputAbs mInput;
-
-		/// match connected with this source
-		const DuelMatch* mMatch;
 };

--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -35,10 +35,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* implementation */
 
-ScriptedInputSource::ScriptedInputSource(const std::string& filename, PlayerSide playerside, unsigned int difficulty)
+ScriptedInputSource::ScriptedInputSource(const std::string& filename, PlayerSide playerside, unsigned int difficulty,
+										 const DuelMatch* match)
 : mDifficulty(difficulty)
 , mSide(playerside)
 , mDelayDistribution( difficulty/3, difficulty/2 )
+, mMatch(match)
 {
 	mStartTime = SDL_GetTicks();
 
@@ -74,6 +76,8 @@ ScriptedInputSource::ScriptedInputSource(const std::string& filename, PlayerSide
 
 	// clean up stack
 	lua_pop(mState, lua_gettop(mState));
+
+	IScriptableComponent::setMatch(const_cast<DuelMatch*>(match));
 }
 
 ScriptedInputSource::~ScriptedInputSource() = default;
@@ -88,14 +92,6 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 	lua_setglobal(mState, "__WANT_RIGHT");
 	lua_pushboolean(mState, false);
 	lua_setglobal(mState, "__WANT_JUMP");
-
-	if (getMatch() == nullptr)
-	{
-		return {};
-	} else
-	{
-		IScriptableComponent::setMatch( const_cast<DuelMatch*>(getMatch()) );
-	}
 	lua_getglobal(mState, "__OnStep");
 	callLuaFunction();
 
@@ -143,3 +139,4 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 
 	return {wantleft, wantright, wantjump};
 }
+

--- a/src/ScriptedInputSource.h
+++ b/src/ScriptedInputSource.h
@@ -53,11 +53,10 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 		/// The constructor automatically loads and initializes the script
 		/// with the given filename. The side parameter tells the script
 		/// which side is it on.
-		ScriptedInputSource(const std::string& filename, PlayerSide side, unsigned int difficulty);
+		ScriptedInputSource(const std::string& filename, PlayerSide side, unsigned int difficulty, const DuelMatch* match);
 		~ScriptedInputSource() override;
 
 		PlayerInputAbs getNextInput() override;
-		using InputSource::getMatch;
 
 	private:
 
@@ -73,4 +72,7 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 		double mJumpDelay = 0;
 		std::normal_distribution<double> mDelayDistribution;
 		std::default_random_engine mRandom;
+
+		/// match connected with this source
+		const DuelMatch* mMatch = nullptr;
 };

--- a/src/state/LocalGameState.cpp
+++ b/src/state/LocalGameState.cpp
@@ -43,7 +43,7 @@ LocalGameState::LocalGameState()
 
 }
 
-std::shared_ptr<InputSource> LocalGameState::createInputSource( IUserConfigReader& config, PlayerSide side ) {
+std::shared_ptr<InputSource> LocalGameState::createInputSource( IUserConfigReader& config, PlayerSide side, const DuelMatch* match ) {
 	std::string prefix = side == LEFT_PLAYER ? "left" : "right";
 	try
 	{
@@ -56,7 +56,7 @@ std::shared_ptr<InputSource> LocalGameState::createInputSource( IUserConfigReade
 		else
 		{
 			return std::make_shared<ScriptedInputSource>("scripts/" + config.getString(prefix + "_script_name"),
-														 side, config.getInteger(prefix + "_script_strength"));
+														 side, config.getInteger(prefix + "_script_strength"), match);
 		}
 	} catch (std::exception& e)
 	{
@@ -72,9 +72,6 @@ void LocalGameState::init()
 	PlayerIdentity leftPlayer = config->loadPlayerIdentity(LEFT_PLAYER, false);
 	PlayerIdentity rightPlayer = config->loadPlayerIdentity(RIGHT_PLAYER, false);
 
-	std::shared_ptr<InputSource> leftInput = createInputSource(*config, LEFT_PLAYER);
-	std::shared_ptr<InputSource> rightInput = createInputSource(*config, RIGHT_PLAYER);
-
 	// create default replay name
 	setDefaultReplayName(leftPlayer.getName(), rightPlayer.getName());
 
@@ -84,6 +81,8 @@ void LocalGameState::init()
 	playSound(SoundManager::WHISTLE, ROUND_START_SOUND_VOLUME);
 
 	mMatch.reset(new DuelMatch( false, config->getString("rules")));
+	std::shared_ptr<InputSource> leftInput = createInputSource(*config, LEFT_PLAYER, mMatch.get());
+	std::shared_ptr<InputSource> rightInput = createInputSource(*config, RIGHT_PLAYER, mMatch.get());
 	mMatch->setPlayers(leftPlayer, rightPlayer);
 	mMatch->setInputSources(leftInput, rightInput);
 

--- a/src/state/LocalGameState.h
+++ b/src/state/LocalGameState.h
@@ -41,7 +41,7 @@ class LocalGameState : public GameState
 		const char* getStateName() const override;
 
 	private:
-		std::shared_ptr<InputSource> createInputSource( IUserConfigReader& config, PlayerSide side );
+		std::shared_ptr<InputSource> createInputSource( IUserConfigReader& config, PlayerSide side, const DuelMatch* match );
 
 		bool mWinner;
 

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -67,7 +67,6 @@ void NetworkGameState::init()
 	mOwnSide = (PlayerSide)config->getInteger("network_side");
 	mUseRemoteColor = config->getBool("use_remote_color");
 	mLocalInput.reset(new LocalInputSource(getInputMgr().beginGame(mOwnSide)));
-	mLocalInput->setMatch(mMatch.get());
 
 	// game is not started until two players are connected
 	mMatch->pause();


### PR DESCRIPTION
This PR moves the conversion of absolute inputs to relative inputs into the Match class, and allows us to make the (basic) InputSource independent of the Match. I think this will also be useful for #100.