### PR TITLE
fixed bot API bug

### DIFF
--- a/src/IScriptableComponent.cpp
+++ b/src/IScriptableComponent.cpp
@@ -272,7 +272,7 @@ int simulate_steps( lua_State* state )
 	PhysicWorld* world = getWorld( state );
 	// get the initial ball settings
 	lua_checkstack(state, 5);
-	int steps = lua_tointeger( state, 1);
+	int steps = lua_to_int( state, 1);
 	float x = lua_tonumber( state, 2);
 	float y = lua_tonumber( state, 3);
 	float vx = lua_tonumber( state, 4);

--- a/src/IScriptableComponent.cpp
+++ b/src/IScriptableComponent.cpp
@@ -193,7 +193,7 @@ int set_blob_data(lua_State* state)
 {
 	auto s = getMatch( state );
 	lua_checkstack(state, 5);
-	int side = lua_tointeger(state, 1);
+	int side = luaL_checkinteger(state, 1);
 	float x = lua_tonumber( state, 2);
 	float y = lua_tonumber( state, 3);
 	float vx = lua_tonumber( state, 4);
@@ -210,7 +210,7 @@ int set_blob_data(lua_State* state)
 int get_blob_pos(lua_State* state)
 {
 	auto s = getMatch( state );
-	PlayerSide side = (PlayerSide) lua_to_int( state, -1 );
+	PlayerSide side = (PlayerSide)luaL_checkinteger( state, -1 );
 	lua_pop(state, 1);
 	assert( side == LEFT_PLAYER || side == RIGHT_PLAYER );
 	return lua_pushvector(state, s->getBlobPosition(side), VectorType::POSITION);
@@ -219,7 +219,7 @@ int get_blob_pos(lua_State* state)
 int get_blob_vel(lua_State* state)
 {
 	auto s = getMatch( state );
-	PlayerSide side = (PlayerSide) lua_to_int( state, -1 );
+	PlayerSide side = (PlayerSide)luaL_checkinteger( state, -1 );
 	lua_pop(state, 1);
 	assert( side == LEFT_PLAYER || side == RIGHT_PLAYER );
 	return lua_pushvector(state, s->getBlobVelocity(side), VectorType::VELOCITY);
@@ -228,7 +228,7 @@ int get_blob_vel(lua_State* state)
 int get_score( lua_State* state )
 {
 	auto s = getMatch( state );
-	PlayerSide side = (PlayerSide) lua_to_int( state, -1 );
+	PlayerSide side = (PlayerSide)luaL_checkinteger( state, -1 );
 	lua_pop(state, 1);
 	assert( side == LEFT_PLAYER || side == RIGHT_PLAYER );
 	lua_pushinteger(state, s->getScore(side));
@@ -238,7 +238,7 @@ int get_score( lua_State* state )
 int get_touches( lua_State* state )
 {
 	auto s = getMatch( state );
-	PlayerSide side = (PlayerSide) lua_to_int( state, -1 );
+	PlayerSide side = (PlayerSide)luaL_checkinteger( state, -1 );
 	lua_pop(state, 1);
 	assert( side == LEFT_PLAYER || side == RIGHT_PLAYER );
 	lua_pushinteger(state, s->getTouches(side));


### PR DESCRIPTION
When passing an input to the `simulate` function of the bot api, it was converted using `lua_tointeger`. Unfortunately, this function silently returns `0` if the source number is fractional. This caused `gintonicV9.lua` and `axji-0-2.lua` to behave rather uselessly in many cases.

There are two possible fixes:
* Ensure that we get an integer, by using `luaL_checkinteger`, which will print an error message if the input is non-integral.
* Round floats to the nearest int.

I've implemented the second option here, because that automatically also fixes the existing bots.

Results when playing against `reduced.lua`:
```
gintonicV9.lua vs reduced.lua: 0 - 15 in 88 seconds of game time
=> gintonicV9.lua vs reduced.lua: 2 - 15 in 7594 seconds of game time

axji-0-2.lua vs reduced.lua: 0 - 15 in 39 seconds of game time
=> axji-0-2.lua vs reduced.lua: 0 - 15 in 3256 seconds of game time
```

Thus these bots go from essentially broken to at least reasonably competent.