### PR TITLE
Botbench

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,9 @@ endif ()
 if (UNIX AND (NOT ANDROID))
 	add_executable(blobby-runtest EXCLUDE_FROM_ALL runtest.cpp ${blobby_SRC})
 	target_link_libraries(blobby-runtest ${BLOBBY_COMMON_LIBS} ${OPENGL_LIBRARIES})
+
+	add_executable(botbench EXCLUDE_FROM_ALL botbench.cpp ${blobby_SRC})
+	target_link_libraries(botbench ${BLOBBY_COMMON_LIBS} ${OPENGL_LIBRARIES})
 endif ()
 
 if (WIN32)

--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -82,6 +82,10 @@ ScriptedInputSource::ScriptedInputSource(const std::string& filename, PlayerSide
 
 ScriptedInputSource::~ScriptedInputSource() = default;
 
+void ScriptedInputSource::setWaitTime(int wait_in_ms) {
+	mWaitTime = wait_in_ms;
+}
+
 PlayerInputAbs ScriptedInputSource::getNextInput()
 {
 	bool serving = false;
@@ -120,7 +124,7 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 		lua_pop(mState, stacksize);
 	}
 
-	if (mStartTime + WAITING_TIME > SDL_GetTicks() && serving)
+	if (mStartTime + mWaitTime > SDL_GetTicks() && serving)
 		return {};
 
 	// random jump delay depending on difficulty

--- a/src/ScriptedInputSource.h
+++ b/src/ScriptedInputSource.h
@@ -56,11 +56,14 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 		ScriptedInputSource(const std::string& filename, PlayerSide side, unsigned int difficulty, const DuelMatch* match);
 		~ScriptedInputSource() override;
 
+		void setWaitTime(int wait_in_ms);
+
 		PlayerInputAbs getNextInput() override;
 
 	private:
 
 		unsigned int mStartTime;
+		unsigned int mWaitTime = WAITING_TIME;
 
 		// ki strength values
 		int mDifficulty;

--- a/src/botbench.cpp
+++ b/src/botbench.cpp
@@ -1,0 +1,132 @@
+/*=============================================================================
+Blobby Volley 2
+Copyright (C) 2023 Daniel Knobe (daniel-knobe@web.de)
+Copyright (C) 2023 Erik Schultheis (erik-schultheis@freenet.de)
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+=============================================================================*/
+
+/* includes */
+#include <ctime>
+#include <cstring>
+#include <sstream>
+#include <atomic>
+#include <thread>
+#include <iostream>
+
+#include <SDL.h>
+
+#include "Global.h"
+#include "UserConfig.h"
+#include "FileSystem.h"
+#include "ScriptedInputSource.h"
+#include "DuelMatch.h"
+#include "replays/ReplayRecorder.h"
+#include "FileWrite.h"
+
+/* implementation */
+
+struct DuelResult {
+	std::string LeftPlayer;
+	std::string RightPlayer;
+	int LeftScore;
+	int RightScore;
+	int Duration;
+};
+
+DuelResult duel(std::string left, std::string right, bool verbose=false);
+void present(const DuelResult& result);
+
+int main(int argc, char* argv[])
+{
+	if(argc < 3) {
+		std::cerr << "Usage: " << argv[0] << " [LEFT] [RIGHT]\n";
+		return EXIT_FAILURE;
+	}
+
+	std::string left_bot = argv[1];
+	std::string right_bot = argv[2];
+
+	FileSystem filesys(argv[0]);
+	filesys.setWriteDir("/tmp");
+	filesys.addToSearchPath("data");
+
+	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
+	srand(SDL_GetTicks());
+
+	try
+	{
+		auto result = duel( left_bot, right_bot, true );
+		present( result );
+	} catch (const boost::exception& ex) {
+		// error handling
+		std::cerr <<  boost::diagnostic_information(ex);
+		exit(EXIT_FAILURE);
+	} catch (std::exception& ex) {
+		std::cerr << ex.what();
+		exit(EXIT_FAILURE);
+	}
+
+	return EXIT_SUCCESS;
+}
+
+
+DuelResult duel(std::string left, std::string right, bool verbose) {
+	DuelMatch match{false, "default.lua"};
+	auto leftInput = std::make_shared<ScriptedInputSource>("scripts/" + left, LEFT_PLAYER, 0, &match);
+	auto rightInput = std::make_shared<ScriptedInputSource>("scripts/" + right, RIGHT_PLAYER, 0, &match);
+	leftInput->setWaitTime(5);
+	rightInput->setWaitTime(5);
+
+	match.setPlayers(PlayerIdentity{}, PlayerIdentity{});
+	match.setInputSources(leftInput, rightInput);
+
+	ReplayRecorder recorder;
+	recorder.setGameSpeed( 75 );
+	recorder.setGameRules( "default.lua" );
+	recorder.setPlayerNames(left, right);
+
+	int timer = 0;
+
+	while (match.winningPlayer() == NO_PLAYER)
+	{
+		++timer;
+		recorder.record(match.getState());
+		match.step();
+		if(verbose && timer % 10000 == 0) {
+			std::cout << timer / 1000 << "k steps: ";
+			std::cout << match.getScore(LEFT_PLAYER) << " - " << match.getScore(RIGHT_PLAYER) << "\n";
+		}
+
+		// stop at 12 hours
+		if(timer > 75 * 60 * 60 * 12) {
+			break;
+		}
+	}
+
+	recorder.record( match.getState() );
+	recorder.finalize( match.getScore(LEFT_PLAYER), match.getScore(RIGHT_PLAYER) );
+
+	FileWrite save_target{"bot-fight.bvr"};
+	recorder.save(save_target);
+
+	return {std::move(left), std::move(right), match.getScore(LEFT_PLAYER), match.getScore(RIGHT_PLAYER), timer / 75};
+}
+
+void present(const DuelResult& result) {
+	std::cout << result.LeftPlayer << " vs " << result.RightPlayer << ": "
+	          << result.LeftScore << " - " << result.RightScore << " in "
+			  << result.Duration << " seconds of game time\n";
+}

--- a/test/benchmark-bots.py
+++ b/test/benchmark-bots.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+This is a utility script that uses the `botbench` helper to
+generate a table of performances of bots against each other.
+This can help identify regressions in bot play.
+"""
+
+from pathlib import Path
+import subprocess
+from tabulate import tabulate
+
+
+bots_path = Path() / "data" / "scripts"
+bot_names = [str(bot.relative_to(bots_path)) for bot in bots_path.glob("*.lua")]
+
+assert len(bot_names) != 0, "No bots found"
+
+
+score_table = [[i] + [0] * len(bot_names) for i in bot_names]
+time_table = [[i] + [0] * len(bot_names) for i in bot_names]
+
+
+for lid in range(len(bot_names)):
+    left_bot = bot_names[lid]
+    for rid in range(lid, len(bot_names)):
+        right_bot = bot_names[rid]
+        print(f"Running {left_bot} vs {right_bot}")
+        output = subprocess.check_output(["./botbench", left_bot, right_bot], text=True)  # type: str
+        marker = f"{left_bot} vs {right_bot}:"
+        for line in output.splitlines():
+            if marker in line:
+                result = line[len(marker):]
+                score, _, time = result.partition("in")
+                left, _, right = score.partition("-")
+                score_table[lid][1 + rid] = int(left)
+                score_table[rid][1 + lid] = int(right)
+                time = time.split()[0]
+                time_table[rid][1 + lid] = int(time)
+
+print("Scores:")
+print(tabulate(score_table, headers=[""] + bot_names))
+
+print()
+print("Durations:")
+print(tabulate(time_table, headers=[""] + bot_names))


### PR DESCRIPTION
This PR adds a utility program `botbench` that can be used to let two bots play against each other, without rendering, so that the simulation speed it only limited by the CPU. 
Additionally, I've added a python script that checks all combinations of bots against each other. 
This should help us to make more informed decisions when changing bot-related stuff, hopefully catching regressions earlier. Currently, `Union.lua` is certainly broken, but most other bots are also worse than I'd like. 

For reference, here are the current results:
```
Scores:
                  hyp014.lua    gintonicV9.lua    reduced.lua    com_11.lua    Union.lua    axji-0-2.lua    Union3.lua
--------------  ------------  ----------------  -------------  ------------  -----------  --------------  ------------
hyp014.lua                11                 1              0             2           15               0             9
gintonicV9.lua            15                11              1            15           15              15            15
reduced.lua               15                15             15            15           15              15            15
com_11.lua                15                17              0            13           15              15            15
Union.lua                  0                 0              0             0           15               0             0
axji-0-2.lua              15                 3              8             7           15              15            15
Union3.lua                15                11              0             9           15               2            11

Durations:
                  hyp014.lua    gintonicV9.lua    reduced.lua    com_11.lua    Union.lua    axji-0-2.lua    Union3.lua
--------------  ------------  ----------------  -------------  ------------  -----------  --------------  ------------
hyp014.lua               311                 0              0             0            0               0             0
gintonicV9.lua           535              2047              0             0            0               0             0
reduced.lua              719              3533          12165             0            0               0             0
com_11.lua              1064              5178           3932          3743            0               0             0
Union.lua                 39                75             63            53           76               0             0
axji-0-2.lua             157              1600           4793          4230           66           12507             0
Union3.lua              1420              3651           1633          3525           41            1148          4343

```