### PR TITLE
Server crash

### DIFF
--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -154,7 +154,7 @@ void DedicatedServer::processPackets()
 			case ID_NEW_INCOMING_CONNECTION:
 				mConnectedClients++;
 				SWLS_Connections++;
-				syslog(LOG_DEBUG, "New incoming connection from %s, %d clients connected now", packet->playerId.toString().c_str(), mConnectedClients);
+				syslog(LOG_DEBUG, "Connection incoming (%d) from %s, %d clients connected now", packet->data[0], packet->playerId.toString().c_str(), mConnectedClients);
 
 				if ( !mAcceptNewPlayers )
 				{
@@ -163,7 +163,7 @@ void DedicatedServer::processPackets()
 					mServer->Send( &stream, HIGH_PRIORITY, RELIABLE_ORDERED, 0, packet->playerId, false);
 					mServer->CloseConnection( packet->playerId, true );
 					mConnectedClients--;
-					syslog(LOG_DEBUG, "Connection not accepted, %d clients connected now", mConnectedClients);
+					syslog(LOG_DEBUG, "Connection not accepted (%d) from %s, %d clients connected now", packet->data[0], packet->playerId.toString().c_str(), mConnectedClients);
 				}
 
 				break;
@@ -176,7 +176,7 @@ void DedicatedServer::processPackets()
 				// delete the disconnectiong player
 				if( player != mPlayerMap.end() )
 				{
-					syslog(LOG_DEBUG, "Disconnected player %s", player->second->getName().c_str());
+					const std::string playerName = player->second->getName();
 					if( player->second->getGame() )
 						player->second->getGame()->injectPacket( packet );
 
@@ -187,13 +187,13 @@ void DedicatedServer::processPackets()
 						// player iterator is invalid after erase
 					}
 					mMatchMaker.removePlayer(packet->playerId);
+					syslog(LOG_DEBUG, "Player removed (%d) from %s (%s), %d players available", packet->data[0], packet->playerId.toString().c_str(), player->second->getName().c_str(), (int)mPlayerMap.size());
 				}
 				else
 				{
 				}
 
-				int pid = packet->data[0];
-				syslog(LOG_DEBUG, "Connection %s closed via %d, %d clients connected now", packet->playerId.toString().c_str(),  pid, mConnectedClients);
+				syslog(LOG_DEBUG, "Connection closed (%d) from %s, %d clients connected now", packet->data[0], packet->playerId.toString().c_str(), mConnectedClients);
 				break;
 			}
 			// player connects to server
@@ -211,7 +211,7 @@ void DedicatedServer::processPackets()
 					mPlayerMap[packet->playerId] = newplayer;
 				}
 				mMatchMaker.addPlayer(packet->playerId, newplayer);
-				syslog(LOG_DEBUG, "New player \"%s\" connected from %s ", newplayer->getName().c_str(), packet->playerId.toString().c_str());
+				syslog(LOG_DEBUG, "Player added (%d) from %s (%s), %d players available", packet->data[0], packet->playerId.toString().c_str(), newplayer->getName().c_str(), (int)mPlayerMap.size());
 
 				// if this is a locally hosted server, any player that connects automatically joins an
 				// open game

--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -328,8 +328,8 @@ void DedicatedServer::processBlobbyServerPresent( PlayerID source, RakNet::BitSt
 	int minor = 0;
 	bool wrongPackageSize = true;
 
-	// current client has bitSize 64
-	if( stream.GetNumberOfBitsUsed() == 64)
+	// current client has bitSize 72
+	if( stream.GetNumberOfBitsUsed() == 72)
 	{
 		stream.Read(major);
 		stream.Read(minor);

--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -237,7 +237,11 @@ void DedicatedServer::processPackets()
 			}
 			case ID_LOBBY:
 			{
-				/// \todo assert that the player send an ID_ENTER_SERVER before
+				if( !mMatchMaker.hasPlayer(packet->playerId) ) {
+					syslog(LOG_NOTICE, "Received Lobby packet (%d) from %s, who is not in the lobby. Ignoring.",
+						   packet_id, packet->playerId.toString().c_str());
+					break;
+				}
 
 				// which player is wanted as opponent
 				RakNet::BitStream stream(packet->data, packet->length, false);

--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -220,7 +220,7 @@ void DedicatedServer::processPackets()
 					syslog(LOG_ERR, "An error occurred while processing packet (%d) from %s: %s",
 						   packet_id, packet->playerId.toString().c_str(), error.what());
 				}
-
+				break;
 			default:
 				syslog(LOG_DEBUG, "Unknown packet %d received\n", packet_id);
 		}

--- a/src/server/DedicatedServer.cpp
+++ b/src/server/DedicatedServer.cpp
@@ -201,7 +201,8 @@ void DedicatedServer::processPackets()
 					}
 					mMatchMaker.removePlayer(packet->playerId);
 					syslog(LOG_DEBUG, "Player removed (%d) from %s (%s), %d players available",
-						   packet_id, packet->playerId.toString().c_str(), player->second->getName().c_str(), (int)mPlayerMap.size());
+						   packet_id, packet->playerId.toString().c_str(),
+						   player->second->getName().c_str(), (int)mPlayerMap.size());
 				}
 
 				syslog(LOG_DEBUG, "Connection closed (%d) from %s, %d clients connected now",
@@ -339,7 +340,9 @@ void DedicatedServer::processBlobbyServerPresent( PlayerID source, RakNet::BitSt
 
 	if (wrongPackageSize)
 	{
-		std::cerr << "outdated client tried to connect! Unable to determine client version due to packet size mismatch : " << stream.GetNumberOfBitsUsed() << "\n" ;
+		syslog(LOG_NOTICE, "Outdated client tried to connect! "
+						   "Unable to determine client version due to packet size mismatch: %d",
+						   stream.GetNumberOfBitsUsed());
 		stream2.Write((unsigned char)ID_VERSION_MISMATCH);
 		stream2.Write((int)BLOBBY_VERSION_MAJOR);
 		stream2.Write((int)BLOBBY_VERSION_MINOR);
@@ -446,7 +449,8 @@ void DedicatedServer::createGame(NetworkPlayer& left,
 	SWLS_Games++;
 
 	/// \todo add some logging?
-	syslog(LOG_DEBUG, "Created game \"%s\" vs. \"%s\", rules:%s", left.getName().c_str(), right.getName().c_str(), rules.c_str());
+	syslog(LOG_DEBUG, "Created game '%s' vs. '%s', rules: '%s'",
+		   left.getName().c_str(), right.getName().c_str(), rules.c_str());
 	mGameList.push_back(newgame);
 }
 

--- a/src/server/DedicatedServer.h
+++ b/src/server/DedicatedServer.h
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <deque>
 #include <iosfwd>
 #include <memory>
+#include <set>
 
 #include "NetworkPlayer.h"
 #include "NetworkMessage.h"
@@ -84,12 +85,7 @@ class DedicatedServer
 		// does not add the game to the active game list
 		void createGame(NetworkPlayer& left, NetworkPlayer& right,
 						PlayerSide switchSide, const std::string& rules, int scoreToWin, float gamespeed);
-		// broadcasts the current server  status to all waiting clients
 
-		// member variables
-		// number of currently connected clients
-		/// \todo is this already counted by raknet?
-		unsigned int mConnectedClients;
 		// raknet server used
 		const std::unique_ptr<RakServer> mServer;
 
@@ -104,6 +100,13 @@ class DedicatedServer
 		std::list< std::shared_ptr<NetworkGame> > mGameList;
 		std::map< PlayerID, std::shared_ptr<NetworkPlayer>> mPlayerMap;
 		std::mutex mPlayerMapMutex;
+
+		// Keeps track of all open connections, so we can discard packets that arrive
+		// for non-connected players
+		std::set<PlayerID> mActiveConnections;
+
+		bool isConnected(PlayerID player) const;
+		bool addConnection(PlayerID player);
 
 		// packet queue
 		std::deque<packet_ptr> mPacketQueue;

--- a/src/server/DedicatedServer.h
+++ b/src/server/DedicatedServer.h
@@ -59,6 +59,7 @@ class DedicatedServer
 
 		// server processing
 		void queuePackets(); // sort incoming packets into queues. called from raknet thread!
+		///! \brief This function handles the packet processing loop for any non-game packet.
 		void processPackets();
 		void updateGames();
 
@@ -79,12 +80,16 @@ class DedicatedServer
 		void allowNewPlayers( bool allow );
 
 	private:
-		// packet handling functions / utility functions
-		void processBlobbyServerPresent( const packet_ptr& packet );
 		// creates a new game with those players
 		// does not add the game to the active game list
 		void createGame(NetworkPlayer& left, NetworkPlayer& right,
 						PlayerSide switchSide, const std::string& rules, int scoreToWin, float gamespeed);
+
+		// packet handling functions / utility functions
+		/// This function encapsulates processing our custom packets from the server main loop.
+		void processSingleMessage(MessageType message_id, PlayerID source, RakNet::BitStream& data);
+		void processEnterServer(PlayerID source, RakNet::BitStream& stream);
+		void processBlobbyServerPresent(PlayerID source, RakNet::BitStream& stream);
 
 		// raknet server used
 		const std::unique_ptr<RakServer> mServer;

--- a/src/server/MatchMaker.cpp
+++ b/src/server/MatchMaker.cpp
@@ -275,7 +275,6 @@ void MatchMaker::receiveLobbyPacket( PlayerID player, RakNet::BitStream& stream 
 	unsigned char byte;
 	auto reader = createGenericReader(&stream);
 	reader->byte(byte);
-	reader->byte(byte);
 	LobbyPacketType type = LobbyPacketType(byte);
 
 	if( type == LobbyPacketType::OPEN_GAME )

--- a/src/server/MatchMaker.cpp
+++ b/src/server/MatchMaker.cpp
@@ -462,3 +462,8 @@ void MatchMaker::setAllowNewGames( bool allow )
 {
 	mAllowNewGames = allow;
 }
+
+bool MatchMaker::hasPlayer(PlayerID id) const
+{
+	return mPlayerMap.find(id) != mPlayerMap.end();
+}

--- a/src/server/MatchMaker.h
+++ b/src/server/MatchMaker.h
@@ -70,6 +70,9 @@ public:
 	unsigned getOpenGamesCount() const;
 	std::vector<unsigned> getOpenGameIDs() const;
 
+	/// checks whether the player with the given `id` is in the lobby.
+	bool hasPlayer(PlayerID id) const;
+
 private:
 	struct OpenGame;
 

--- a/src/server/MatchMaker.h
+++ b/src/server/MatchMaker.h
@@ -79,7 +79,7 @@ private:
 	/// add a new game to the gamelist
 	unsigned addGame( OpenGame game );
 	void joinGame(PlayerID player, unsigned gameID, const std::string& password = "");
-	void startGame(PlayerID host, PlayerID client);
+	void startGame(PlayerID host_id, PlayerID client_id);
 
 	void removeGame( unsigned id );
 	void removePlayerFromAllGames( PlayerID player );


### PR DESCRIPTION
I think these changes will fix #97.  There might still be other lurking problems, though.

I've implemented the following:
 1) Server keeps track of who has opened and closed a connection, and discards any packets that come in from an already closed connection.
 2) If a lobby packet comes in and the sending player is not actually in the lobby (i.e. known to the MatchMaker), then we drop this packet.
 3) Processing of our game messages happens in a try-catch block, so if one message causes something to go wrong, we won't crash the entire server. There is the question of what state the server is in after an exception, tough... silently running in a broken state is probably not helpful. Maybe we should disconnect the player with the offending packet, to make sure at least that gets a full reset.
 4) I've changed the asserts that caused the crash in #97 to throws instead. With 3), this should now not cause a crash. 