### PR TITLE
refactored and cleaned up bot api

### DIFF
--- a/src/DuelMatch.cpp
+++ b/src/DuelMatch.cpp
@@ -41,7 +41,7 @@ DuelMatch::DuelMatch(bool remote, const std::string& rules, int score_to_win) :
 		score_to_win = IUserConfigReader::createUserConfigReader("config.xml")->getInteger("scoretowin");
 	}
 
-	mLogic = createGameLogic(rules, this, score_to_win);
+	mLogic = createGameLogic(rules, score_to_win);
 	mPhysicWorld.reset( new PhysicWorld() );
 
 	setInputSources(std::make_shared<InputSource>(), std::make_shared<InputSource>());
@@ -77,7 +77,7 @@ void DuelMatch::setRules(const std::string& rulesFile, int score_to_win)
 {
 	if( score_to_win == 0)
 		score_to_win = getScoreToWin();
-	mLogic = createGameLogic(rulesFile, this, score_to_win);
+	mLogic = createGameLogic(rulesFile, score_to_win);
 }
 
 
@@ -97,9 +97,9 @@ void DuelMatch::step()
 	}
 
 	// do steps in physic and logic
-	mLogic->step( getState() );
 	mPhysicWorld->step( mTransformedInput[LEFT_PLAYER], mTransformedInput[RIGHT_PLAYER],
 						mLogic->isBallValid(), mLogic->isGameRunning() );
+	mLogic->step( getState() );
 
 	// check for all hit events
 

--- a/src/GameLogic.h
+++ b/src/GameLogic.h
@@ -238,6 +238,6 @@ extern const std::string FALLBACK_RULES_NAME;
 extern const std::string TEMP_RULES_NAME;
 
 // functions for creating a game logic object
-GameLogicPtr createGameLogic(const std::string& rulefile, DuelMatch* match, int score_to_win);
+GameLogicPtr createGameLogic(const std::string& rulefile, int score_to_win);
 
 

--- a/src/IScriptableComponent.h
+++ b/src/IScriptableComponent.h
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <memory>
+#include "DuelMatchState.h"
 
 struct lua_State;
 class DuelMatch;
@@ -43,6 +44,9 @@ class IScriptableComponent
 {
 	public:
 		struct Access;
+
+		const DuelMatchState& getMatchState() const;
+
 	protected:
 		IScriptableComponent();
 		virtual ~IScriptableComponent();
@@ -57,14 +61,15 @@ class IScriptableComponent
 		// load lua functions
 		void setGameConstants();
 		void setGameFunctions();
-		void setMatch( DuelMatch* m ) { mGame = m; };
-		DuelMatch* getMatch() const { return mGame; };
+
+		void setMatchState(const DuelMatchState& state);
 
 		lua_State* mState;
 
 	private:
-		DuelMatch* mGame;
 		// we save a dummy physic world here to do simulations
 		std::unique_ptr<PhysicWorld> mDummyWorld;
+
+		DuelMatchState mCachedState;
 };
 

--- a/src/ScriptedInputSource.h
+++ b/src/ScriptedInputSource.h
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include <string>
 #include <random>
+#include <deque>
 
 #include "Global.h"
 #include "InputSource.h"
@@ -53,26 +54,21 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 		/// The constructor automatically loads and initializes the script
 		/// with the given filename. The side parameter tells the script
 		/// which side is it on.
-		ScriptedInputSource(const std::string& filename, PlayerSide side, unsigned int difficulty, const DuelMatch* match);
+		ScriptedInputSource(const std::string& filename, PlayerSide side, unsigned int difficulty,
+							const DuelMatch* match);
 		~ScriptedInputSource() override;
 
 		PlayerInputAbs getNextInput() override;
 
 	private:
-
 		unsigned int mStartTime;
 
-		// ki strength values
-		int mDifficulty;
 
 		PlayerSide mSide;
 
-		// error data
-		bool mLastJump = false;
-		double mJumpDelay = 0;
-		std::normal_distribution<double> mDelayDistribution;
-		std::default_random_engine mRandom;
+		// Difficulty setting of the AI. Small values mean stronger AI
+		int mDifficulty;
 
-		/// match connected with this source
-		const DuelMatch* mMatch = nullptr;
+		std::default_random_engine mRandom;
+		const DuelMatch* mMatch;
 };

--- a/src/server/MatchMaker.cpp
+++ b/src/server/MatchMaker.cpp
@@ -441,7 +441,7 @@ void MatchMaker::addGameSpeedOption( int speed )
 
 void MatchMaker::addRuleOption( const std::string& file )
 {
-	auto gamelogic = createGameLogic(file, nullptr, 1);
+	auto gamelogic = createGameLogic(file, 1);
 	/// \todo check rule validity and load author and description
 	mPossibleGameRules.emplace_back(Rule{file, gamelogic->getTitle(), gamelogic->getAuthor(), ""});
 }

--- a/src/state/LobbyStates.cpp
+++ b/src/state/LobbyStates.cpp
@@ -158,7 +158,7 @@ void LobbyState::step_impl()
 					mPreferedSpeed = std::distance( speeds.begin(), closest_speed );
 
 					// rules
-					auto gamelogic = createGameLogic(config->getString("rules"), nullptr, 1);
+					auto gamelogic = createGameLogic(config->getString("rules"), 1);
 					std::string rule = gamelogic->getTitle();
 					auto& rules = mStatus.mPossibleRules;
 					auto found = std::find( rules.begin(), rules.end(), rule);


### PR DESCRIPTION
This is the first patch towards my improved implementation of the bot api. With this, the difficulty simulation for bots will be temporarily disabled, but I think it is easier to review the underlying structural changes first, and then have the re-implementation of difficulty as a second PR.

The fundamental idea is this: Instead of having scripts (`IScriptableComponent`) deal with a direct reference to an underlying match, instead have it store and operate on a `DuelMatchState`. This makes it much easier to intercept and modify the  observed state from a centralized place.

A first benefit is that it is now much easier to implement player side normalization on the C++ side, and let all of the lua API assume that the bot plays on the left. Together with the removal of some debugging helper codes (I think creating a dedicated bot debugging tool will be much better than polluting our bot API with this debugging stuff) and the lua-side difficulty emulation, this also makes `bot_api.lua` quite a bit shorter and simpler.

I've also removed the `print` function that we provided in our bot api, as this is in any case immediately overwritten by `print` from the lua standard lib. I've also updated the library loading so that potentially unsafe functions from the lua standard library are not exposed to the bot. 
