### PR TITLE
fix query text glitch for some languages

### DIFF
--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -105,11 +105,28 @@ void GameState::displayQueryPrompt(const int height, TextManager::STRING title, 
 	imgui.doOverlay(GEN_ID, Vector2(0, height), Vector2(800, height + 200));
 	imgui.doText(GEN_ID, Vector2(400, height + 30), title, TF_ALIGN_CENTER);
 
-	if (imgui.doButton(GEN_ID, Vector2(400 - 60, height + 90), std::get<0>(opt1), TF_ALIGN_RIGHT))
+	const std::string& leftOptionText = imgui.getText(std::get<0>(opt1));
+	const std::string& rightOptionText = imgui.getText(std::get<0>(opt2));
+
+	const int leftOptionTextLength = TextManager::getUTF8Length(leftOptionText);
+	const int rightOptionTextLength = TextManager::getUTF8Length(rightOptionText);
+
+	int textOffset = 0;
+	if ((leftOptionTextLength + rightOptionTextLength) <= 28)
+	{
+		if (leftOptionTextLength > 14) {
+			textOffset = (leftOptionTextLength - 14) * FONT_WIDTH_NORMAL;
+		}
+		if (rightOptionTextLength > 14) {
+			textOffset = (14 - rightOptionTextLength) * FONT_WIDTH_NORMAL;
+		}
+	}
+
+	if (imgui.doButton(GEN_ID, Vector2(400 - 40 + textOffset, height + 90), leftOptionText, TF_ALIGN_RIGHT))
 	{
 		std::get<1>(opt1)();
 	}
-	if (imgui.doButton(GEN_ID, Vector2(400 + 60, height + 90), std::get<0>(opt2), TF_ALIGN_LEFT))
+	if (imgui.doButton(GEN_ID, Vector2(400 + 40 + textOffset, height + 90), rightOptionText, TF_ALIGN_LEFT))
 	{
 		std::get<1>(opt2)();
 	}

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -421,29 +421,19 @@ void NetworkGameState::step_impl()
 		case OPPONENT_DISCONNECTED:
 		{
 			imgui.doCursor();
-			imgui.doOverlay(GEN_ID, Vector2(100.0, 210.0), Vector2(700.0, 390.0));
-			imgui.doText(GEN_ID, Vector2(140.0, 240.0),	TextManager::GAME_OPP_LEFT);
 
-			if (imgui.doButton(GEN_ID, Vector2(230.0, 290.0), TextManager::LBL_OK))
-			{
-				switchState(new MainMenuState);
-			}
-
-			if (imgui.doButton(GEN_ID, Vector2(350.0, 290.0), TextManager::RP_SAVE))
-			{
-				mSaveReplay = true;
-				imgui.resetSelection();
-			}
-
-			if (imgui.doButton(GEN_ID, Vector2(250.0, 340.0), TextManager::NET_STAY_ON_SERVER))
-			{
-				// Send a blobby server connection request
-				RakNet::BitStream stream;
-				stream.Write((unsigned char)ID_BLOBBY_SERVER_PRESENT);
-				stream.Write(BLOBBY_VERSION_MAJOR);
-				stream.Write(BLOBBY_VERSION_MINOR);
-				mClient->Send(&stream, LOW_PRIORITY, RELIABLE_ORDERED, 0);
-			}
+			displayQueryPrompt(200,
+				TextManager::GAME_OPP_LEFT,
+				std::make_tuple(TextManager::LBL_OK, [&](){ switchState(new MainMenuState); }),
+				std::make_tuple(TextManager::RP_SAVE, [&](){ mSaveReplay = true; imgui.resetSelection(); }),
+				std::make_tuple(TextManager::NET_STAY_ON_SERVER, [&](){
+					// Send a blobby server connection request
+					RakNet::BitStream stream;
+					stream.Write((unsigned char)ID_BLOBBY_SERVER_PRESENT);
+					stream.Write(BLOBBY_VERSION_MAJOR);
+					stream.Write(BLOBBY_VERSION_MINOR);
+					mClient->Send(&stream, LOW_PRIORITY, RELIABLE_ORDERED, 0);
+				 }));
 			break;
 		}
 		case DISCONNECTED:


### PR DESCRIPTION
Texts leave the of the screen in queries e.g. in german when opponent left the network game. This fix tries to handle such cases by trying to use the space of the other option.