### PR TITLE
Some UI Improvements

### DIFF
--- a/data/lang_de.xml
+++ b/data/lang_de.xml
@@ -22,12 +22,12 @@
 
 	<string english = "show again" translation = "nochmal ansehen" />
 	<string english = "play" translation = "abspielen" />
-	<string english = "delete" translation = "loeschen" />
+	<string english = "delete" translation = "löschen" />
 	<string english = "info" translation = "info" />
 	<string english = "duration:" translation = "dauer:" />
 	<string english = "result:" translation = "ergebnis:" />
 	<string english = "checksum error" translation = "checksum error" />
-	<string english = "file is corrupt" translation = "datei beschaedigt" />
+	<string english = "file is corrupt" translation = "datei beschädigt" />
 	<string english = "version error" translation = "version error" />
 	<string english = "file is outdated" translation = "datei veraltet" />
 	<string english = "receiving replay..." translation = "empfange replay..." />
@@ -38,7 +38,7 @@
 	<string english = "try again" translation = "nochmal" />
 	<string english = "waiting for opponent..." translation = "warte auf mitspieler" />
 	<string english = "opponent left the game" translation = "gegner hat das spiel verlassen" />
-	<string english = "game paused" translation = "spiel pausieren" />
+	<string english = "game paused" translation = "spiel pausiert" />
 	<string english = "quit" translation = "verlassen" />
 	
 	<string english = "scan for servers" translation = "server suchen" />
@@ -78,7 +78,7 @@
 	<string english = "right player" translation = "rechter spieler" />
 	
 	<string english = "red" translation = "rot" />
-	<string english = "green" translation = "gruen" />
+	<string english = "green" translation = "grün" />
 	<string english = "blue" translation = "blau" />
 	<string english = "morphing blob?" translation = "morphing blob?" />
 	<string english = "keyboard" translation = "tastatur" />
@@ -91,14 +91,14 @@
 	<string english = "jump key" translation = "taste sprung" />
 	<string english = "left button" translation = "button links" />
 	<string english = "right button" translation = "button rechts" />
-	<string english = "press mouse button for" translation = "maustaste druecken fuer" />
-	<string english = "press key for" translation = "taste druecken fuer" />
+	<string english = "press mouse button for" translation = "maustaste drücken für" />
+	<string english = "press key for" translation = "taste drücken für" />
 	<string english = "moving left" translation = "nach links" />
 	<string english = "moving right" translation = "nach rechts" />
 	<string english = "jumping" translation = "springen" />
-	<string english = "press button for" translation = "taste druecken fuer" />
+	<string english = "press button for" translation = "taste drücken für" />
 	<string english = "background:" translation = "hintergrund:" />
-	<string english = "volume:" translation = "lautstaerke:" />
+	<string english = "volume:" translation = "lautstärke:" />
 	<string english = "mute" translation = "stumm" />
 	<string english = "show fps" translation = "fps" />
 	<string english = "show blood" translation = "zeige blut" />

--- a/data/lang_es.xml
+++ b/data/lang_es.xml
@@ -68,13 +68,13 @@
 	<string english = "graphic options" translation = "opciones gráficas" />
 	<string english = "misc options" translation = "opciones varias" />
 	<string english = "video settings" translation = "configuración de vídeo" />
-	<string english = "fullscreen mode" translation = "modo de pantalla completa" />
-	<string english = "window mode" translation = "modo de ventana" />
+	<string english = "fullscreen mode" translation = "pantalla completa" />
+	<string english = "window mode" translation = "ventana" />
 	<string english = "render device" translation = "Cambiar configuración de gráficos" />
 	<string english = "show shadow" translation = "mostrar sombra" />
 	<string english = "blob colors" translation = "colores de las manchas" />
-	<string english = "left player" translation = "reproductor izquierdo" />
-	<string english = "right player" translation = "jugador de la derecha" />
+	<string english = "left player" translation = "izquierda" />
+	<string english = "right player" translation = "derecha" />
 	
 	<string english = "red" translation = "rojo" />
 	<string english = "green" translation = "verde" />

--- a/data/lang_fr.xml
+++ b/data/lang_fr.xml
@@ -80,7 +80,7 @@
 	<string english = "red" translation = "rouge" />
 	<string english = "green" translation = "vert" />
 	<string english = "blue" translation = "bleu" />
-	<string english = "morphing blob?" translation = "blob qui change de couleur?" />
+	<string english = "morphing blob?" translation = "change de couleur?" />
 	<string english = "keyboard" translation = "clavier" />
 	<string english = "mouse" translation = "souris" />
 	<string english = "joystick" translation = "joystick" />

--- a/src/state/GameState.cpp
+++ b/src/state/GameState.cpp
@@ -105,11 +105,28 @@ void GameState::displayQueryPrompt(const int height, TextManager::STRING title, 
 	imgui.doOverlay(GEN_ID, Vector2(0, height), Vector2(800, height + 200));
 	imgui.doText(GEN_ID, Vector2(400, height + 30), title, TF_ALIGN_CENTER);
 
-	if (imgui.doButton(GEN_ID, Vector2(400 - 60, height + 90), std::get<0>(opt1), TF_ALIGN_RIGHT))
+	const std::string& leftOptionText = imgui.getText(std::get<0>(opt1));
+	const std::string& rightOptionText = imgui.getText(std::get<0>(opt2));
+
+	const int leftOptionTextLength = TextManager::getUTF8Length(leftOptionText);
+	const int rightOptionTextLength = TextManager::getUTF8Length(rightOptionText);
+
+	int textOffset = 0;
+	if ((leftOptionTextLength + rightOptionTextLength) <= 28)
+	{
+		if (leftOptionTextLength > 14) {
+			textOffset = (leftOptionTextLength - 14) * FONT_WIDTH_NORMAL;
+		}
+		if (rightOptionTextLength > 14) {
+			textOffset = (14 - rightOptionTextLength) * FONT_WIDTH_NORMAL;
+		}
+	}
+
+	if (imgui.doButton(GEN_ID, Vector2(400 - 40 + textOffset, height + 90), leftOptionText, TF_ALIGN_RIGHT))
 	{
 		std::get<1>(opt1)();
 	}
-	if (imgui.doButton(GEN_ID, Vector2(400 + 60, height + 90), std::get<0>(opt2), TF_ALIGN_LEFT))
+	if (imgui.doButton(GEN_ID, Vector2(400 + 40 + textOffset, height + 90), rightOptionText, TF_ALIGN_LEFT))
 	{
 		std::get<1>(opt2)();
 	}

--- a/src/state/NetworkState.cpp
+++ b/src/state/NetworkState.cpp
@@ -421,29 +421,19 @@ void NetworkGameState::step_impl()
 		case OPPONENT_DISCONNECTED:
 		{
 			imgui.doCursor();
-			imgui.doOverlay(GEN_ID, Vector2(100.0, 210.0), Vector2(700.0, 390.0));
-			imgui.doText(GEN_ID, Vector2(140.0, 240.0),	TextManager::GAME_OPP_LEFT);
 
-			if (imgui.doButton(GEN_ID, Vector2(230.0, 290.0), TextManager::LBL_OK))
-			{
-				switchState(new MainMenuState);
-			}
-
-			if (imgui.doButton(GEN_ID, Vector2(350.0, 290.0), TextManager::RP_SAVE))
-			{
-				mSaveReplay = true;
-				imgui.resetSelection();
-			}
-
-			if (imgui.doButton(GEN_ID, Vector2(250.0, 340.0), TextManager::NET_STAY_ON_SERVER))
-			{
-				// Send a blobby server connection request
-				RakNet::BitStream stream;
-				stream.Write((unsigned char)ID_BLOBBY_SERVER_PRESENT);
-				stream.Write(BLOBBY_VERSION_MAJOR);
-				stream.Write(BLOBBY_VERSION_MINOR);
-				mClient->Send(&stream, LOW_PRIORITY, RELIABLE_ORDERED, 0);
-			}
+			displayQueryPrompt(200,
+				TextManager::GAME_OPP_LEFT,
+				std::make_tuple(TextManager::LBL_OK, [&](){ switchState(new MainMenuState); }),
+				std::make_tuple(TextManager::RP_SAVE, [&](){ mSaveReplay = true; imgui.resetSelection(); }),
+				std::make_tuple(TextManager::NET_STAY_ON_SERVER, [&](){
+					// Send a blobby server connection request
+					RakNet::BitStream stream;
+					stream.Write((unsigned char)ID_BLOBBY_SERVER_PRESENT);
+					stream.Write(BLOBBY_VERSION_MAJOR);
+					stream.Write(BLOBBY_VERSION_MINOR);
+					mClient->Send(&stream, LOW_PRIORITY, RELIABLE_ORDERED, 0);
+				 }));
 			break;
 		}
 		case DISCONNECTED:

--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -118,7 +118,7 @@ void OptionState::step_impl()
 	imgui.doSelectbox(GEN_ID, Vector2(5.0, 50.0), Vector2(375.0, 300.0), mScriptNames, mPlayerOptions[LEFT_PLAYER]);
 	imgui.doSelectbox(GEN_ID, Vector2(425.0, 50.0), Vector2(795.0, 300.0), mScriptNames, mPlayerOptions[RIGHT_PLAYER]);
 
-	imgui.doText(GEN_ID, Vector2(270.0, 310.0), TextManager::OP_DIFFICULTY );
+	imgui.doText(GEN_ID, Vector2(400, 310.0), TextManager::OP_DIFFICULTY, TF_ALIGN_CENTER );
 
 	float f = 1.f - (float)mBotStrength[0] / MAX_BOT_DELAY;
 	imgui.doScrollbar(GEN_ID, Vector2(15.0, 350.0), f);
@@ -269,7 +269,7 @@ void GraphicOptionsState::step_impl()
 	heightOfElement += standardLineHeight;
 
 	//Blob colors:
-	imgui.doText(GEN_ID, Vector2(280.0, heightOfElement), TextManager::OP_BLOB_COLORS);
+	imgui.doText(GEN_ID, Vector2(400.0, heightOfElement), TextManager::OP_BLOB_COLORS, TF_ALIGN_CENTER);
 	heightOfElement += 40.0;
 
 	float playerColorSettingsHeight = heightOfElement;


### PR DESCRIPTION
While looking through #111 , I saw some more opportunities to 
1) shorten some texts -- they need not be a literal translation of the english phrase
2) fix German to use umlauts, which also need one less character
3) actually center-align centered texts, so that these are a) centered in all languages and b) make better use of the available space.