### PR TITLE
reworked difficulty mechanism for bots

### DIFF
--- a/src/ScriptedInputSource.h
+++ b/src/ScriptedInputSource.h
@@ -63,6 +63,11 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 		PlayerInputAbs getNextInput() override;
 
 	private:
+
+		void setInputDelay(int delay);
+		void setBallError(int duration, float amount);
+		int getCurrentDifficulty() const;
+
 		unsigned int mStartTime;
 		unsigned int mWaitTime = WAITING_TIME;
 
@@ -71,6 +76,17 @@ class ScriptedInputSource : public InputSource, public IScriptableComponent
 
 		// Difficulty setting of the AI. Small values mean stronger AI
 		int mDifficulty;
+
+		// artificial reaction delay data
+		int mReactionTime = 0;
+		int mRoundStepCounter = 0;
+		int mOldOppTouches = 0;
+		float mOldBallVx = 0;
+
+		// artificial ball position error
+		Vector2 mBallPosError{0, 0};
+		Vector2 mBallVelError{0, 0};
+		int mBallPosErrorTimer = 0;
 
 		std::default_random_engine mRandom;
 		const DuelMatch* mMatch;


### PR DESCRIPTION
This PR implements a new mechanism to handle difficulty settings for bots. 
Instead of continuous random disturbances to the ball, which can lead to jittery bot behaviour, this new implementation does two things:
1) Random ball (velocity) error: Add a random error to the ball velocity. Importantly, update the (virtual) ball position that the bot observes in such a way that it it consistent with the reported error, so that, e.g., estimated impact points do not change each step. Furthermore, only add this once in a while, to further reduce any possible jittering effect caused by the bot getting updated positions. These errors appear when the ball bounces (changes speed in x direction), and stay for a certain amount of time, and then are removed again. Keeping them too long would make the bot look really stupid. 
2) Random "reaction time": Whenever the opponent hits the ball, the bot just does not do anything (does not even call into lua) for a few frames, to simulate a reaction time. 

Both of these effects are connected to a time, so that they become stronger the longer the current exchange is running, until they get reset when a player scores (Q: Only reset when opponent scores?)

There are quite a few numbers here that can be tweaked to adapt the bot behaviour, but I think we need to do some play-testing to figure out how to set these values to get a good difficulty curve.
