### PR TITLE
fix rare base64 crash + added test

### DIFF
--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -142,7 +142,7 @@ std::string encode( const char* begin, const char* end, int newlines)
 	const unsigned groups     = length / 3;
 	const unsigned total_data = (groups + extra) * 4;
 	newlines -= newlines % 4;
-	const unsigned linefeeds = newlines > 0 ? total_data / newlines : 0;
+	const unsigned linefeeds = newlines > 0 ? total_data / newlines - (total_data % newlines ? 0 : 1) : 0;
 
 	std::string buffer(total_data + linefeeds, '\0');
 
@@ -153,7 +153,7 @@ std::string encode( const char* begin, const char* end, int newlines)
 	for(unsigned i = 0; i < groups; ++i)
 	{
 		encode(read, write);
-		if( newlines > 0 && (i+1) * 4 >= static_cast<unsigned>(last_newline + newlines) )
+		if( newlines > 0 && (i+1) * 4 >= static_cast<unsigned>(last_newline + newlines) && write != buffer.end() )
 		{
 			*write = '\n';
 			write++;

--- a/test/Base64Test.cpp
+++ b/test/Base64Test.cpp
@@ -90,4 +90,16 @@ BOOST_AUTO_TEST_CASE( encode_decode_multiline )
     BOOST_CHECK( decode(encode(text, 8)) == text );
 }
 
+BOOST_AUTO_TEST_CASE( encode_decode_multiline_data_multiple_of_newline )
+{
+    std::vector<uint8_t> text = { '1', '2', '3', '4', '5', '6', '7', '8', '1', '2', '3', '4', '5', '6', '7', '8', '1', '2', '3', '4', '5', '6', '7', '8' };
+    BOOST_CHECK( decode(encode(text, 8)) == text );
+}
+
+BOOST_AUTO_TEST_CASE( encode_decode_multiline_data_multiple_of_newline_with_extra )
+{
+    std::vector<uint8_t> text = { '1', '2', '3', '4', '5', '6', '7', '8', '1', '2', '3', '4', '5', '6', '7', '8' };
+    BOOST_CHECK( decode(encode(text, 8)) == text );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
if resulting base64 is multiple of linefeed in encoding with extra group, the data was written incorrectly for this extra group because of wrong buffer calculation.