### PR TITLE
modification to bot difficulty

### DIFF
--- a/src/ScriptedInputSource.cpp
+++ b/src/ScriptedInputSource.cpp
@@ -165,8 +165,10 @@ PlayerInputAbs ScriptedInputSource::getNextInput()
 
 	if(!mMatch->getBallActive())
 	{
-		mRoundStepCounter = 0;
-		setInputDelay( 0 );
+        if(!serving || mDifficulty < 15) {
+            mRoundStepCounter = 0;
+            setInputDelay(0);
+        }
 	}
 	else
 	{


### PR DESCRIPTION
Depending on the difficulty, the bots' play starts getting weaker the more time passes in the game. However, in the old code, this would reset whenever the bot scored, meaning a really bad player wouldn't ever make it far enough into the game to play against the bot at its weakest.

This is changed here, so that if we have an easy difficulty, we use the time since the opponent's last score to determine play strength. This, the bot will keep getting weaker (up to its maximum) as long as the player doesn't manage to score a point.