### PR TITLE
when creating lan server set fps to fps in config.xml instead of 75

### DIFF
--- a/src/state/NetworkSearchState.cpp
+++ b/src/state/NetworkSearchState.cpp
@@ -360,7 +360,7 @@ void NetworkSearchState::step_impl()
 			std::vector<std::string> rule_vec{config.getString("rules")};
 
 
-			DedicatedServer server(info, rule_vec, std::vector<float>{ SpeedController::getMainInstance()->getGameSpeed() }, 4, true);
+			DedicatedServer server(info, rule_vec, std::vector<float>{ config.getFloat("gamefps") }, 4, true);
 			SpeedController scontroller( 10 );
 			gKillHostThread = false;
 			while(!gKillHostThread)


### PR DESCRIPTION
Reported in discord.

When creating a local server we used always 75fps from the SpeedController.
Most of the setting are from the config.xml so we do it here too.