### PR TITLE
[ci] Update actions/checkout to latest version 6

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install ninja-build
           TOOLCHAIN="${ANDROID_NDK}/build/cmake/android.toolchain.cmake"
           echo "TOOLCHAIN=${TOOLCHAIN}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get Boost
         # no need to build, we use only the header-only parts of boost
         run: |

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -22,7 +22,7 @@ jobs:
             libsdl2-dev \
             libphysfs-dev \
             libboost-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get CMake
         # note: newer versions of cmake have changed the naming scheme to use lower-case 'linux',
         # which will break this script

--- a/.github/workflows/compilers.yaml
+++ b/.github/workflows/compilers.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "CXX=${CXX}" >> $GITHUB_ENV
           CC="${{matrix.compiler.cc}}" 
           echo "CC=${CC}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Configure
         run:  cmake .
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
             sdl2 \
             physfs \
             boost
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # Check that blobby builds
       - name: Configure CMake and Build
         run: |

--- a/.github/workflows/vcpkg.yaml
+++ b/.github/workflows/vcpkg.yaml
@@ -6,8 +6,8 @@ jobs:
   Build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           cmake -B . -S . -DCMAKE_TOOLCHAIN_FILE="c:/vcpkg/scripts/buildsystems/vcpkg.cmake"
-          cmake --build . 
+          cmake --build .


### PR DESCRIPTION
Fixes warning that Node.js 20 support will end in June