### PR TITLE
Add optional volleyball set matches

### DIFF
--- a/data/config.xml
+++ b/data/config.xml
@@ -32,5 +32,6 @@
 	<var name="right_script_strength" value="13"/>
 	<var name="additional_network_server" value="0.0.0.0"/>
 	<var name="rules" value="default.lua"/>
+	<var name="sets_enabled" value="false"/>
 </userconfig>
 

--- a/data/lang_cs.xml
+++ b/data/lang_cs.xml
@@ -40,6 +40,8 @@
 	<string english = "opponent left the game" translation = "Protihráč opustil hru" />
 	<string english = "game paused" translation = "Hra pozastavena" />
 	<string english = "quit" translation = "Odejít" />
+	<string english = "wins set" translation = "vyhrává set" />
+	<string english = "next set" translation = "další set" />
 	
 	<string english = "scan for servers" translation = "Vyhledat server" />
 	<string english = "direct connect" translation = "Přímé spojení" />
@@ -118,6 +120,7 @@
 	<string english = "medium" translation = "Střední" />
 	<string english = "strong" translation = "Těžká" />
 	<string english = "rules:" translation = "Pravidla:" />
+	<string english = "play sets" translation = "hrát sety" />
 	
 	<string english = "please visit https://blobbyvolley.de for a new version of blobby volley" translation = "Navštivte, prosím, https://blobbyvolley.de kvůli nové verzi Blobby Volley" />
 </language>

--- a/data/lang_de.xml
+++ b/data/lang_de.xml
@@ -40,6 +40,8 @@
 	<string english = "opponent left the game" translation = "gegner hat das spiel verlassen" />
 	<string english = "game paused" translation = "spiel pausiert" />
 	<string english = "quit" translation = "verlassen" />
+	<string english = "wins set" translation = "gewinnt den Satz" />
+	<string english = "next set" translation = "nächster Satz" />
 	
 	<string english = "scan for servers" translation = "server suchen" />
 	<string english = "direct connect" translation = "direktverbindung" />
@@ -118,6 +120,7 @@
 	<string english = "medium" translation = "mittel" />
 	<string english = "strong" translation = "schwer" />
 	<string english = "rules:" translation = "Regeln:" />
+	<string english = "play sets" translation = "Sätze spielen" />
 	
 	<string english = "please visit https://blobbyvolley.de for a new version of blobby volley" translation = "Besuche https://blobbyvolley.de für eine neue Version von blobby volley" />
 </language>

--- a/data/lang_en.xml
+++ b/data/lang_en.xml
@@ -40,6 +40,8 @@
 	<string english = "opponent left the game" translation = "opponent left the game" />
 	<string english = "game paused" translation = "game paused" />
 	<string english = "quit" translation = "quit" />
+	<string english = "wins set" translation = "wins set" />
+	<string english = "next set" translation = "next set" />
 	
 	<string english = "scan for servers" translation = "scan for servers" />
 	<string english = "direct connect" translation = "direct connect" />
@@ -117,6 +119,7 @@
 	<string english = "medium" translation = "medium" />
 	<string english = "strong" translation = "strong" />
 	<string english = "rules:" translation = "rules:" />
+	<string english = "play sets" translation = "play sets" />
 	
 	<string english = "please visit https://blobbyvolley.de for a new version of blobby volley" translation = "please visit https://blobbyvolley.de for a new version of blobby volley" />
 </language>

--- a/data/lang_es.xml
+++ b/data/lang_es.xml
@@ -39,6 +39,8 @@
 	<string english = "opponent left the game" translation = "el oponente abandonó el juego" />
 	<string english = "game paused" translation = "juego en pausa" />
 	<string english = "quit" translation = "salir" />
+	<string english = "wins set" translation = "gana el set" />
+	<string english = "next set" translation = "siguiente set" />
 	
 	<string english = "scan for servers" translation = "buscar servidores" />
 	<string english = "direct connect" translation = "conexión directa" />
@@ -116,6 +118,7 @@
 	<string english = "medium" translation = "medio" />
 	<string english = "strong" translation = "fuerte" />
 	<string english = "rules:" translation = "reglas:" />
+	<string english = "play sets" translation = "jugar sets" />
 	
 	<string english = "please visit https://blobbyvolley.de for a new version of blobby volley" translation = "Por favor visite https://blobbyvolley.de para una nueva versión de blobby volley" />
 </language>

--- a/data/lang_fr.xml
+++ b/data/lang_fr.xml
@@ -40,6 +40,8 @@
 	<string english = "opponent left the game" translation = "l'adversaire a quitte le match" />
 	<string english = "game paused" translation = "pause" />
 	<string english = "quit" translation = "quitter" />
+	<string english = "wins set" translation = "gagne le set" />
+	<string english = "next set" translation = "set suivant" />
 	
 	<string english = "scan for servers" translation = "recherche des serveurs" />
 	<string english = "direct connect" translation = "connexion directe" />
@@ -118,6 +120,7 @@
 	<string english = "medium" translation = "moyen" />
 	<string english = "strong" translation = "fort" />
 	<string english = "rules:" translation = "règles:" />
+	<string english = "play sets" translation = "jouer en sets" />
 	
 	<string english = "please visit https://blobbyvolley.de for a new version of blobby volley" translation = "veuillez visiter https://blobbyvolley.de for a new version of blobby volley" />
 </language>

--- a/data/lang_it.xml
+++ b/data/lang_it.xml
@@ -40,6 +40,8 @@
 	<string english = "opponent left the game" translation = "l'avversario ha lasciato la partita" />
 	<string english = "game paused" translation = "gioco in pausa" />
 	<string english = "quit" translation = "esci" />
+	<string english = "wins set" translation = "vince il set" />
+	<string english = "next set" translation = "set successivo" />
 	
 	<string english = "scan for servers" translation = "ricerca server" />
 	<string english = "direct connect" translation = "connessione diretta" />
@@ -117,6 +119,7 @@
 	<string english = "medium" translation = "normale" />
 	<string english = "strong" translation = "intelligente" />
 	<string english = "rules:" translation = "regole del gioco:" />
+	<string english = "play sets" translation = "gioca set" />
 	
 	<string english = "please visit https://blobbyvolley.de for a new version of blobby volley" translation = "visita https://blobbyvolley.de per le nuove versioni di blobby volley" />
 </language>

--- a/data/rules/modern_volley.lua
+++ b/data/rules/modern_volley.lua
@@ -1,0 +1,35 @@
+__AUTHOR__ = "Blobby Volley 2 Developers"
+__TITLE__  = "Modern Volley Rules"
+
+function IsWinning(lscore, rscore)
+	if lscore >= SCORE_TO_WIN and lscore >= rscore + 2 then
+		return true
+	end
+	if rscore >= SCORE_TO_WIN and rscore >= lscore + 2 then
+		return true
+	end
+	return false
+end
+
+function OnBallHitsPlayer(player)
+	if touches(player) > 3 then
+		mistake(player, opponent(player), 1)
+	end
+end
+
+function OnBallHitsWall(player)
+end
+
+function OnBallHitsNet(player)
+end
+
+function OnBallHitsGround(player)
+	mistake(player, opponent(player), 1)
+end
+
+function OnGame()
+end
+
+function HandleInput(player, left, right, up)
+	return left, right, up
+end

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set(common_SRC
 	)
 
 set (blobby_SRC ${common_SRC} ${inputdevice_SRC}
+	MatchSeries.cpp MatchSeries.h
 	Blood.cpp Blood.h
 	TextManager.cpp TextManager.h
 	IMGUI.cpp IMGUI.h

--- a/src/MatchSeries.cpp
+++ b/src/MatchSeries.cpp
@@ -1,0 +1,82 @@
+#include "MatchSeries.h"
+
+#include <cstdlib>
+
+MatchFormat matchFormatForRules(const std::string& rulesFile)
+{
+	return rulesFile == "modern_volley.lua" ? MatchFormat::MODERN_VOLLEY : MatchFormat::STANDARD;
+}
+
+MatchSeries::MatchSeries(MatchFormat format, bool enabled)
+	: mFormat(format), mEnabled(enabled), mCurrentSet(1), mSetsWon{0, 0}
+{
+}
+
+bool MatchSeries::isSeries() const
+{
+	return mEnabled;
+}
+
+int MatchSeries::currentSet() const
+{
+	return mCurrentSet;
+}
+
+int MatchSeries::scoreToWin() const
+{
+	if (mFormat == MatchFormat::MODERN_VOLLEY)
+		return mCurrentSet == 5 ? 15 : 25;
+	return 15;
+}
+
+PlayerSide MatchSeries::firstServer() const
+{
+	const PlayerSide player = mCurrentSet % 2 == 1 ? LEFT_PLAYER : RIGHT_PLAYER;
+	return playerOnSide(player);
+}
+
+bool MatchSeries::sidesSwapped() const
+{
+	return isSeries() && mCurrentSet % 2 == 0;
+}
+
+PlayerSide MatchSeries::playerOnSide(PlayerSide side) const
+{
+	if (side == NO_PLAYER || !sidesSwapped())
+		return side;
+	return side == LEFT_PLAYER ? RIGHT_PLAYER : LEFT_PLAYER;
+}
+
+bool MatchSeries::isSetWon(int leftScore, int rightScore) const
+{
+	const int target = scoreToWin();
+	return (leftScore >= target || rightScore >= target) && std::abs(leftScore - rightScore) >= 2;
+}
+
+void MatchSeries::finishSet(PlayerSide winner, int leftScore, int rightScore)
+{
+	if (!isSeries() || matchWinner() != NO_PLAYER || winner == NO_PLAYER || !isSetWon(leftScore, rightScore))
+		return;
+
+	++mSetsWon[winner];
+	if (matchWinner() == NO_PLAYER)
+		++mCurrentSet;
+}
+
+int MatchSeries::setsWon(PlayerSide player) const
+{
+	if (player == LEFT_PLAYER)
+		return mSetsWon[0];
+	if (player == RIGHT_PLAYER)
+		return mSetsWon[1];
+	return 0;
+}
+
+PlayerSide MatchSeries::matchWinner() const
+{
+	if (mSetsWon[0] >= 3)
+		return LEFT_PLAYER;
+	if (mSetsWon[1] >= 3)
+		return RIGHT_PLAYER;
+	return NO_PLAYER;
+}

--- a/src/MatchSeries.h
+++ b/src/MatchSeries.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+#include "Global.h"
+
+enum class MatchFormat
+{
+	STANDARD,
+	MODERN_VOLLEY
+};
+
+MatchFormat matchFormatForRules(const std::string& rulesFile);
+
+class MatchSeries
+{
+public:
+	explicit MatchSeries(MatchFormat format = MatchFormat::STANDARD, bool enabled = false);
+
+	bool isSeries() const;
+	int currentSet() const;
+	int scoreToWin() const;
+	bool sidesSwapped() const;
+	PlayerSide playerOnSide(PlayerSide side) const;
+	PlayerSide firstServer() const;
+
+	bool isSetWon(int leftScore, int rightScore) const;
+	void finishSet(PlayerSide winner, int leftScore, int rightScore);
+	int setsWon(PlayerSide player) const;
+	PlayerSide matchWinner() const;
+
+private:
+	MatchFormat mFormat;
+	bool mEnabled;
+	int mCurrentSet;
+	int mSetsWon[MAX_PLAYERS];
+};

--- a/src/TextManager.cpp
+++ b/src/TextManager.cpp
@@ -191,6 +191,8 @@ void TextManager::setDefault()
 	mStrings[GAME_OPP_LEFT] = "opponent left the game";
 	mStrings[GAME_PAUSED] = "game paused";
 	mStrings[GAME_QUIT] = "quit";
+	mStrings[GAME_WINS_SET] = "wins set";
+	mStrings[GAME_NEXT_SET] = "next set";
 
 	mStrings[NET_SERVER_SCAN] = "scan for servers";
 	mStrings[NET_DIRECT_CONNECT] = "direct connect";
@@ -267,6 +269,7 @@ void TextManager::setDefault()
 	mStrings[OP_MEDIUM] = "medium";
 	mStrings[OP_STRONG] = "strong";
 	mStrings[OP_RULES] = "rules:";
+	mStrings[OP_PLAY_SETS] = "play sets";
 
 	mStrings[UPDATE_NOTIFICATION] = "please visit https://blobbyvolley.de for a new version of blobby volley";
 }

--- a/src/TextManager.h
+++ b/src/TextManager.h
@@ -84,6 +84,8 @@ class TextManager
 			GAME_OPP_LEFT,
 			GAME_PAUSED,
 			GAME_QUIT,
+			GAME_WINS_SET,
+			GAME_NEXT_SET,
 
 			// network texts
 			NET_SERVER_SCAN,
@@ -162,6 +164,7 @@ class TextManager
 			OP_MEDIUM,
 			OP_STRONG,
 			OP_RULES,
+			OP_PLAY_SETS,
 
 			UPDATE_NOTIFICATION,
 

--- a/src/state/LocalGameState.cpp
+++ b/src/state/LocalGameState.cpp
@@ -34,17 +34,22 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "LocalInputSource.h"
 #include "ScriptedInputSource.h"
 
+#include <sstream>
+
 /* implementation */
 LocalGameState::~LocalGameState() = default;
 
 LocalGameState::LocalGameState()
-	: mWinner(false), mRecorder(new ReplayRecorder())
+	: mWinner(false), mSetFinished(false), mSetWinner(NO_PLAYER),
+	  mFinishedSetNumber(0), mFinishedLeftScore(0), mFinishedRightScore(0),
+	  mRecorder(new ReplayRecorder())
 {
 
 }
 
-std::shared_ptr<InputSource> LocalGameState::createInputSource( IUserConfigReader& config, PlayerSide side, const DuelMatch* match ) {
-	std::string prefix = side == LEFT_PLAYER ? "left" : "right";
+std::shared_ptr<InputSource> LocalGameState::createInputSource(IUserConfigReader& config, PlayerSide player,
+	                                                           PlayerSide side, const DuelMatch* match) {
+	std::string prefix = player == LEFT_PLAYER ? "left" : "right";
 	try
 	{
 		// these operations may throw, i.e., when the script is not found (should not happen)
@@ -56,7 +61,7 @@ std::shared_ptr<InputSource> LocalGameState::createInputSource( IUserConfigReade
 		else
 		{
 			return std::make_shared<ScriptedInputSource>("scripts/" + config.getString(prefix + "_script_name"),
-														 side, config.getInteger(prefix + "_script_strength"), match);
+													 side, config.getInteger(prefix + "_script_strength"), match);
 		}
 	} catch (std::exception& e)
 	{
@@ -71,6 +76,8 @@ void LocalGameState::init()
 	std::shared_ptr<IUserConfigReader> config = IUserConfigReader::createUserConfigReader("config.xml");
 	PlayerIdentity leftPlayer = config->loadPlayerIdentity(LEFT_PLAYER, false);
 	PlayerIdentity rightPlayer = config->loadPlayerIdentity(RIGHT_PLAYER, false);
+	mBlobbyRules = config->getString("rules");
+	mSeries = MatchSeries(matchFormatForRules(mBlobbyRules), config->getBool("sets_enabled", false));
 
 	// create default replay name
 	setDefaultReplayName(leftPlayer.getName(), rightPlayer.getName());
@@ -80,16 +87,18 @@ void LocalGameState::init()
 
 	playSound(SoundManager::WHISTLE, ROUND_START_SOUND_VOLUME);
 
-	mMatch.reset(new DuelMatch( false, config->getString("rules")));
-	std::shared_ptr<InputSource> leftInput = createInputSource(*config, LEFT_PLAYER, mMatch.get());
-	std::shared_ptr<InputSource> rightInput = createInputSource(*config, RIGHT_PLAYER, mMatch.get());
+	mMatch.reset(new DuelMatch(false, mBlobbyRules, mSeries.isSeries() ? mSeries.scoreToWin() : 0));
+	std::shared_ptr<InputSource> leftInput = createInputSource(*config, LEFT_PLAYER, LEFT_PLAYER, mMatch.get());
+	std::shared_ptr<InputSource> rightInput = createInputSource(*config, RIGHT_PLAYER, RIGHT_PLAYER, mMatch.get());
 	mMatch->setPlayers(leftPlayer, rightPlayer);
 	mMatch->setInputSources(leftInput, rightInput);
+	if (mSeries.isSeries())
+		mMatch->setServingPlayer(mSeries.firstServer());
 
 	mRecorder->setPlayerNames(leftPlayer.getName(), rightPlayer.getName());
 	mRecorder->setPlayerColors( leftPlayer.getStaticColor(), rightPlayer.getStaticColor() );
 	mRecorder->setGameSpeed((float)config->getInteger("gamefps"));
-	mRecorder->setGameRules( config->getString("rules") );
+	mRecorder->setGameRules(mBlobbyRules);
 }
 
 
@@ -102,7 +111,7 @@ void LocalGameState::step_impl()
 	{
 		displayErrorMessageBox();
 	}
-	else if (mSaveReplay)
+	else if (mSaveReplay && !mSeries.isSeries())
 	{
 		if ( displaySaveReplayPrompt() )
 		{
@@ -111,17 +120,26 @@ void LocalGameState::step_impl()
 	}
 	else if (mMatch->isPaused())
 	{
-		displayQueryPrompt(200,
-			TextManager::LBL_CONF_QUIT,
-			std::make_tuple(TextManager::LBL_YES, [&](){ switchState(new MainMenuState); }),
-			std::make_tuple(TextManager::LBL_NO,  [&](){ mMatch->unpause(); }),
-			std::make_tuple(TextManager::RP_SAVE, [&](){ mSaveReplay = true; imgui.resetSelection(); }));
+		if (mSeries.isSeries())
+			displaySeriesQuitPrompt();
+		else
+			displayQueryPrompt(200,
+				TextManager::LBL_CONF_QUIT,
+				std::make_tuple(TextManager::LBL_YES, [&](){ switchState(new MainMenuState); }),
+				std::make_tuple(TextManager::LBL_NO,  [&](){ mMatch->unpause(); }),
+				std::make_tuple(TextManager::RP_SAVE, [&](){ mSaveReplay = true; imgui.resetSelection(); }));
 
 		imgui.doCursor();
 	}
+	else if (mSetFinished)
+	{
+		displaySetWinnerScreen();
+	}
 	else if (mWinner)
 	{
-		displayWinningPlayerScreen( mMatch->winningPlayer() );
+		const PlayerSide winnerSide = mSeries.isSeries()
+			? mSeries.playerOnSide(mSeries.matchWinner()) : mMatch->winningPlayer();
+		displayWinningPlayerScreen(winnerSide);
 		if (imgui.doButton(GEN_ID, Vector2(310, 340), TextManager::LBL_OK))
 		{
 			switchState(new MainMenuState());
@@ -130,7 +148,7 @@ void LocalGameState::step_impl()
 		{
 			switchState(new LocalGameState());
 		}
-		if (imgui.doButton(GEN_ID, Vector2(500, 390), TextManager::RP_SAVE, TF_ALIGN_CENTER))
+		if (!mSeries.isSeries() && imgui.doButton(GEN_ID, Vector2(500, 390), TextManager::RP_SAVE, TF_ALIGN_CENTER))
 		{
 			mSaveReplay = true;
 			imgui.resetSelection();
@@ -154,20 +172,86 @@ void LocalGameState::step_impl()
 	}
 	else
 	{
-		mRecorder->record(mMatch->getState());
+		if (!mSeries.isSeries())
+			mRecorder->record(mMatch->getState());
 		mMatch->step();
 
 		if (mMatch->winningPlayer() != NO_PLAYER)
 		{
-			mWinner = true;
-			mRecorder->record(mMatch->getState());
-			mRecorder->finalize( mMatch->getScore(LEFT_PLAYER), mMatch->getScore(RIGHT_PLAYER) );
+			if (mSeries.isSeries())
+			{
+				mSetWinner = mMatch->winningPlayer();
+				mFinishedSetNumber = mSeries.currentSet();
+				mFinishedLeftScore = mMatch->getScore(LEFT_PLAYER);
+				mFinishedRightScore = mMatch->getScore(RIGHT_PLAYER);
+				mSeries.finishSet(mSeries.playerOnSide(mSetWinner), mFinishedLeftScore, mFinishedRightScore);
+				mWinner = mSeries.matchWinner() != NO_PLAYER;
+				mSetFinished = !mWinner;
+			}
+			else
+			{
+				mWinner = true;
+				mRecorder->record(mMatch->getState());
+				mRecorder->finalize(mMatch->getScore(LEFT_PLAYER), mMatch->getScore(RIGHT_PLAYER));
+			}
 		}
 
 		presentGame();
 	}
 
 	presentGameUI();
+	if (mSeries.isSeries() && !mSetFinished)
+		presentSeriesUI();
+}
+
+void LocalGameState::startNextSet()
+{
+	std::shared_ptr<IUserConfigReader> config = IUserConfigReader::createUserConfigReader("config.xml");
+	const PlayerSide leftPlayer = mSeries.playerOnSide(LEFT_PLAYER);
+	const PlayerSide rightPlayer = mSeries.playerOnSide(RIGHT_PLAYER);
+
+	mMatch.reset(new DuelMatch(false, mBlobbyRules, mSeries.scoreToWin()));
+	mMatch->setPlayers(config->loadPlayerIdentity(leftPlayer, false),
+	                   config->loadPlayerIdentity(rightPlayer, false));
+	mMatch->setInputSources(createInputSource(*config, leftPlayer, LEFT_PLAYER, mMatch.get()),
+	                        createInputSource(*config, rightPlayer, RIGHT_PLAYER, mMatch.get()));
+	mMatch->setServingPlayer(mSeries.firstServer());
+	mSetFinished = false;
+	mSetWinner = NO_PLAYER;
+	playSound(SoundManager::WHISTLE, ROUND_START_SOUND_VOLUME);
+}
+
+void LocalGameState::presentSeriesUI()
+{
+	getIMGUI().doText(GEN_ID, Vector2(212, 24),
+	                  std::to_string(mSeries.setsWon(mSeries.playerOnSide(LEFT_PLAYER))), TF_ALIGN_CENTER);
+	getIMGUI().doText(GEN_ID, Vector2(588, 24),
+	                  std::to_string(mSeries.setsWon(mSeries.playerOnSide(RIGHT_PLAYER))), TF_ALIGN_CENTER);
+}
+
+void LocalGameState::displaySetWinnerScreen()
+{
+	IMGUI& imgui = getIMGUI();
+	imgui.doOverlay(GEN_ID, Vector2(0, 150), Vector2(800, 450));
+	imgui.doText(GEN_ID, Vector2(400, 205), mMatch->getPlayer(mSetWinner).getName(), TF_ALIGN_CENTER);
+	std::ostringstream result;
+	result << imgui.getText(TextManager::GAME_WINS_SET) << " " << mFinishedSetNumber << "   "
+	       << mFinishedLeftScore << " - " << mFinishedRightScore;
+	imgui.doText(GEN_ID, Vector2(400, 265), result.str(), TF_ALIGN_CENTER);
+	if (imgui.doButton(GEN_ID, Vector2(400, 340), TextManager::GAME_NEXT_SET, TF_ALIGN_CENTER))
+		startNextSet();
+	imgui.doCursor();
+}
+
+void LocalGameState::displaySeriesQuitPrompt()
+{
+	IMGUI& imgui = getIMGUI();
+	imgui.doOverlay(GEN_ID, Vector2(0, 200), Vector2(800, 400));
+	imgui.doText(GEN_ID, Vector2(400, 230), TextManager::LBL_CONF_QUIT, TF_ALIGN_CENTER);
+	if (imgui.doButton(GEN_ID, Vector2(330, 300), TextManager::LBL_YES, TF_ALIGN_CENTER))
+		switchState(new MainMenuState);
+	if (imgui.doButton(GEN_ID, Vector2(470, 300), TextManager::LBL_NO, TF_ALIGN_CENTER))
+		mMatch->unpause();
 }
 
 const char* LocalGameState::getStateName() const

--- a/src/state/LocalGameState.h
+++ b/src/state/LocalGameState.h
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #pragma once
 
 #include "GameState.h"
+#include "MatchSeries.h"
 
 class ReplayRecorder;
 class InputSource;
@@ -41,9 +42,21 @@ class LocalGameState : public GameState
 		const char* getStateName() const override;
 
 	private:
-		std::shared_ptr<InputSource> createInputSource( IUserConfigReader& config, PlayerSide side, const DuelMatch* match );
+		std::shared_ptr<InputSource> createInputSource(IUserConfigReader& config, PlayerSide player,
+		                                               PlayerSide side, const DuelMatch* match);
+		void startNextSet();
+		void presentSeriesUI();
+		void displaySetWinnerScreen();
+		void displaySeriesQuitPrompt();
 
 		bool mWinner;
+		bool mSetFinished;
+		PlayerSide mSetWinner;
+		int mFinishedSetNumber;
+		int mFinishedLeftScore;
+		int mFinishedRightScore;
+		MatchSeries mSeries;
+		std::string mBlobbyRules;
 
 		std::unique_ptr<ReplayRecorder> mRecorder;
 };

--- a/src/state/OptionsState.cpp
+++ b/src/state/OptionsState.cpp
@@ -917,6 +917,7 @@ void MiscOptionsState::save()
 	mOptionConfig.setString("language", mLanguage);
 	mOptionConfig.setString("background", mBackgrounds[mBackground]);
 	mOptionConfig.setString("rules", mRules[mRule] + ".lua");
+	mOptionConfig.setBool("sets_enabled", mSetsEnabled);
 	mOptionConfig.saveFile("config.xml");
 
 	SpeedController::getMainInstance()->setDrawFPS(mOptionConfig.getBool("showfps"));
@@ -944,7 +945,11 @@ void MiscOptionsState::step_impl()
 		getApp().getRenderManager().setBackground(std::string("backgrounds/") + mBackgrounds[mBackground]);
 	}
 	imgui.doText(GEN_ID, Vector2(34.0, 190.0), TextManager::OP_RULES);
-	imgui.doSelectbox(GEN_ID, Vector2(34.0, 220.0), Vector2(400.0, 354.0), mRules, mRule);
+	imgui.doSelectbox(GEN_ID, Vector2(34.0, 220.0), Vector2(400.0, 334.0), mRules, mRule);
+	if (imgui.doButton(GEN_ID, Vector2(34.0, 350.0), TextManager::OP_PLAY_SETS))
+		mSetsEnabled = !mSetsEnabled;
+	if (mSetsEnabled)
+		imgui.doImage(GEN_ID, Vector2(16.0, 362.0), "gfx/pfeil_rechts.bmp");
 
 	imgui.doText(GEN_ID, Vector2(484.0, 10.0), TextManager::OP_VOLUME);
 	if (imgui.doScrollbar(GEN_ID, Vector2(484.0, 50.0), mVolume))
@@ -1080,6 +1085,7 @@ void MiscOptionsState::init()
 
 	mShowFPS = mOptionConfig.getBool("showfps");
 	mShowBlood = mOptionConfig.getBool("blood");
+	mSetsEnabled = mOptionConfig.getBool("sets_enabled", false);
 	mVolume = mOptionConfig.getFloat("global_volume");
 	mMute = mOptionConfig.getBool("mute");
 	mGameFPS = mOptionConfig.getInteger("gamefps");

--- a/src/state/OptionsState.h
+++ b/src/state/OptionsState.h
@@ -167,6 +167,7 @@ private:
 	int mGameFPS;
 	bool mShowFPS;
 	bool mShowBlood;
+	bool mSetsEnabled;
 	int mNetworkSide;
 	std::string mLanguage;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRC
 	../src/Clock.cpp          ../src/Clock.h
 	../src/PhysicWorld.cpp    ../src/PhysicWorld.h 
 	../src/GameLogic.cpp      ../src/GameLogic.h
+	../src/MatchSeries.cpp    ../src/MatchSeries.h
 	../src/InputSource.cpp    ../src/InputSource.h
 	../src/IScriptableComponent.cpp ../src/IScriptableComponent.h
 	../src/PlayerIdentity.cpp ../src/PlayerIdentity.h
@@ -33,7 +34,7 @@ if ("${SDL2_LIBRARIES}" STREQUAL "")
 	set(SDL2_LIBRARIES "SDL2::SDL2")
 endif ("${SDL2_LIBRARIES}" STREQUAL "")
 
-add_executable(blobbytest GenericIOTest.cpp FileTest.cpp Base64Test.cpp ${SRC})
+add_executable(blobbytest GenericIOTest.cpp FileTest.cpp Base64Test.cpp MatchSeriesTest.cpp ${SRC})
 
 target_include_directories(blobbytest PRIVATE ${Boost_INCLUDE_DIR} ${PHYSFS_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS} ../src)
 target_compile_definitions(blobbytest PRIVATE "BOOST_TEST_DYN_LINK=1")

--- a/test/MatchSeriesTest.cpp
+++ b/test/MatchSeriesTest.cpp
@@ -1,0 +1,90 @@
+#include <boost/test/unit_test.hpp>
+
+#include "MatchSeries.h"
+
+BOOST_AUTO_TEST_SUITE(match_series_test)
+
+BOOST_AUTO_TEST_CASE(modern_set_requires_two_point_lead)
+{
+	MatchSeries series(MatchFormat::MODERN_VOLLEY, true);
+	BOOST_CHECK(series.isSetWon(25, 23));
+	BOOST_CHECK(!series.isSetWon(25, 24));
+	BOOST_CHECK(series.isSetWon(26, 24));
+}
+
+BOOST_AUTO_TEST_CASE(modern_fifth_set_uses_fifteen_points)
+{
+	MatchSeries series(MatchFormat::MODERN_VOLLEY, true);
+	series.finishSet(LEFT_PLAYER, 25, 20);
+	series.finishSet(RIGHT_PLAYER, 20, 25);
+	series.finishSet(LEFT_PLAYER, 25, 21);
+	series.finishSet(RIGHT_PLAYER, 23, 25);
+	BOOST_CHECK_EQUAL(series.currentSet(), 5);
+	BOOST_CHECK_EQUAL(series.scoreToWin(), 15);
+	BOOST_CHECK(!series.isSetWon(15, 14));
+	BOOST_CHECK(series.isSetWon(16, 14));
+}
+
+BOOST_AUTO_TEST_CASE(series_supports_three_zero_three_one_and_three_two)
+{
+	MatchSeries straight(MatchFormat::MODERN_VOLLEY, true);
+	for (int i = 0; i < 3; ++i)
+		straight.finishSet(LEFT_PLAYER, 25, 20);
+	BOOST_CHECK_EQUAL(straight.matchWinner(), LEFT_PLAYER);
+
+	MatchSeries fourSets(MatchFormat::MODERN_VOLLEY, true);
+	fourSets.finishSet(RIGHT_PLAYER, 20, 25);
+	for (int i = 0; i < 3; ++i)
+		fourSets.finishSet(LEFT_PLAYER, 25, 20);
+	BOOST_CHECK_EQUAL(fourSets.matchWinner(), LEFT_PLAYER);
+
+	MatchSeries fiveSets(MatchFormat::MODERN_VOLLEY, true);
+	fiveSets.finishSet(LEFT_PLAYER, 25, 20);
+	fiveSets.finishSet(RIGHT_PLAYER, 20, 25);
+	fiveSets.finishSet(LEFT_PLAYER, 25, 20);
+	fiveSets.finishSet(RIGHT_PLAYER, 20, 25);
+	fiveSets.finishSet(LEFT_PLAYER, 15, 10);
+	BOOST_CHECK_EQUAL(fiveSets.matchWinner(), LEFT_PLAYER);
+}
+
+BOOST_AUTO_TEST_CASE(standard_series_stays_at_fifteen)
+{
+	MatchSeries series(MatchFormat::STANDARD, true);
+	BOOST_CHECK_EQUAL(series.scoreToWin(), 15);
+	series.finishSet(RIGHT_PLAYER, 13, 15);
+	BOOST_CHECK_EQUAL(series.scoreToWin(), 15);
+}
+
+BOOST_AUTO_TEST_CASE(rule_files_select_the_series_format)
+{
+	BOOST_CHECK(matchFormatForRules("default.lua") == MatchFormat::STANDARD);
+	BOOST_CHECK(matchFormatForRules("classic.lua") == MatchFormat::STANDARD);
+	BOOST_CHECK(matchFormatForRules("modern_volley.lua") == MatchFormat::MODERN_VOLLEY);
+}
+
+BOOST_AUTO_TEST_CASE(sets_can_be_disabled_independently_from_rules)
+{
+	MatchSeries modern(MatchFormat::MODERN_VOLLEY, false);
+	BOOST_CHECK(!modern.isSeries());
+}
+
+BOOST_AUTO_TEST_CASE(players_switch_courts_between_sets)
+{
+	MatchSeries series(MatchFormat::MODERN_VOLLEY, true);
+	BOOST_CHECK(!series.sidesSwapped());
+	BOOST_CHECK_EQUAL(series.playerOnSide(LEFT_PLAYER), LEFT_PLAYER);
+	BOOST_CHECK_EQUAL(series.firstServer(), LEFT_PLAYER);
+
+	series.finishSet(LEFT_PLAYER, 25, 20);
+	BOOST_CHECK(series.sidesSwapped());
+	BOOST_CHECK_EQUAL(series.playerOnSide(LEFT_PLAYER), RIGHT_PLAYER);
+	BOOST_CHECK_EQUAL(series.playerOnSide(RIGHT_PLAYER), LEFT_PLAYER);
+	BOOST_CHECK_EQUAL(series.firstServer(), LEFT_PLAYER);
+	BOOST_CHECK_EQUAL(series.playerOnSide(series.firstServer()), RIGHT_PLAYER);
+
+	series.finishSet(RIGHT_PLAYER, 25, 20);
+	BOOST_CHECK(!series.sidesSwapped());
+	BOOST_CHECK_EQUAL(series.playerOnSide(LEFT_PLAYER), LEFT_PLAYER);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
     "name": "blobby",
     "version-string": "0.1",
-    "dependencies": ["sdl2", "physfs", "boost-smart-ptr", "boost-exception", "boost-crc", "boost-algorithm"]
+    "dependencies": ["sdl2", "physfs", "boost-smart-ptr", "boost-exception", "boost-crc", "boost-algorithm", "boost-test"]
   }


### PR DESCRIPTION
## What changed

- add an optional `Play sets` toggle for local games, disabled by default
- add a `modern_volley` rules entry with rally scoring and a two-point winning margin
- play best-of-five matches, using 25 points for modern sets and 15 for the deciding fifth set
- use 15-point sets for the existing standard and classic rules
- track set wins, alternate the first-serving player, and switch players between courts after each set
- keep configured input profiles attached to the left and right courts when players switch
- show set wins between each player's points and the match clock
- disable replay saving for multi-set matches, whose format is not supported by the replay file
- localize the new controls and set-transition messages

## Impact

Existing local and network games retain their current behavior unless `Play sets` is enabled. Network play is unchanged. The existing `classic` rules remain the side-out scoring option; `modern_volley` supplies the modern rally-scoring format.

## Validation

- Release x64 build with CMake and vcpkg
- existing and new Boost unit tests (`blobbytest`)
- header self-containment target (`test-compile-headers`)
- XML parsing for every language file and `config.xml`
- verified packaged `rules.zip` contains `classic.lua` and `modern_volley.lua`

The new tests cover 25:23, continued play at 25:24, 26:24, the 15-point fifth set, 3:0/3:1/3:2 match results, optional set mode, alternating service, and court changes.
